### PR TITLE
Move optional mocking behind flag

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,8 +14,24 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
-      - name: Test resources
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build common lib
+        run: npm run build
+        working-directory: common/lib
+
+      - name: Build website app
+        run: npm run build
+        working-directory: apps/website
+        env:
+          PUBLIC_STAGE: ${{ env.STAGE }}
+
+      - name: Build users service
+        run: npm run build
+        working-directory: services/users
+
+      - name: Test cdk stacks
         run: |
-          npm install
           npm run test
         working-directory: infrastructure/cdk

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,5 @@ jobs:
       - name: Test resources
         run: |
           npm install
-          npm run build
           npm run test
         working-directory: infrastructure/cdk

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set the stage for testing
         if: ${{ github.actor == 'nektos/act' }}
         run: |
-          echo "STAGE=prod" >> $GITHUB_ENV
+          echo "STAGE=dev" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
 
     # Skip any pushes with commit flag '(skip deploy)'
     # Comment out for testing
-    if: ${{ !contains(github.event.head_commit.message, '(skip deploy)') }}
+    # if: ${{ !contains(github.event.head_commit.message, '(skip deploy)') }}
 
     steps:
       - name: Check out the repo
@@ -44,6 +44,8 @@ jobs:
       - name: Build website app
         run: npm run build
         working-directory: apps/website
+        env:
+          PUBLIC_STAGE: ${{ env.STAGE }}
 
       - name: Build users service
         run: npm run build
@@ -55,13 +57,6 @@ jobs:
       - name: Build and deploy email templates
         run: npm run deploy:templates
 
-      - name: Set deployment outputs
-        run: |
-          export "STACK_KEY=${PROJECT^}${SERVICE^}Stack${STAGE^}"
-          export "DNS_KEY=${PROJECT^}${SERVICE^}DnsName${STAGE^}"
-          export "ARN_KEY=${PROJECT^}${SERVICE^}StackId${STAGE^}"
-          echo "WEBSITE_DNS=$(cat cdk-outputs.json | jq -r --arg stack_key "$STACK_KEY" --arg dns_key "$DNS_KEY" '.[$stack_key][$dns_key]')" >> $GITHUB_ENV
-          echo "WEBSITE_ARN=$(cat cdk-outputs.json | jq -r --arg stack_key "$STACK_KEY" --arg arn_key "$ARN_KEY" '.[$stack_key][$arn_key]')" >> $GITHUB_ENV
         env:
           SERVICE: website
 
@@ -96,7 +91,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Environment* · <https://${{ env.AWS_REGION }}.console.aws.amazon.com/cloudformation/home?region=${{ env.AWS_REGION }}#/stacks/stackinfo?stackId=${{ env.WEBSITE_ARN }}|${{ env.STAGE }}>"
+                      "text": "*Environment* · <https://${{ env.AWS_REGION }}.console.aws.amazon.com/cloudformation/home?region=${{ env.AWS_REGION }}#/stacks|${{ env.STAGE }}>"
                     }
                   ]
                 },
@@ -119,7 +114,7 @@ jobs:
                       },
                       "style": "primary",
                       "value": "preview",
-                      "url": "http://${{ env.WEBSITE_DNS }}"
+                      "url": "http://${{ env.STAGE }}.casimir.co"
                     },
                     {
                       "type": "button",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,16 +69,6 @@ jobs:
         env:
           TARGET_BRANCH: develop
 
-      - name: Set deployment outputs
-        run: |
-          export "STACK_KEY=${PROJECT^}${SERVICE^}Stack${STAGE^}"
-          export "DNS_KEY=${PROJECT^}${SERVICE^}DnsName${STAGE^}"
-          export "ARN_KEY=${PROJECT^}${SERVICE^}StackId${STAGE^}"
-          echo "WEBSITE_DNS=$(cat cdk-outputs.json | jq -r --arg stack_key "$STACK_KEY" --arg dns_key "$DNS_KEY" '.[$stack_key][$dns_key]')" >> $GITHUB_ENV
-          echo "WEBSITE_ARN=$(cat cdk-outputs.json | jq -r --arg stack_key "$STACK_KEY" --arg arn_key "$ARN_KEY" '.[$stack_key][$arn_key]')" >> $GITHUB_ENV
-        env:
-          SERVICE: website
-
       - name: Select success emoji
         if: ${{ success() }}
         run: echo 'EMOJI=:rocket:' >> $GITHUB_ENV
@@ -110,7 +100,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Environment* · <https://${{ env.AWS_REGION }}.console.aws.amazon.com/cloudformation/home?region=${{ env.AWS_REGION }}#/stacks/stackinfo?stackId=${{ env.WEBSITE_ARN }}|${{ env.STAGE }}>"
+                      "text": "*Environment* · <https://${{ env.AWS_REGION }}.console.aws.amazon.com/cloudformation/home?region=${{ env.AWS_REGION }}#/stacks|${{ env.STAGE }}>"
                     }
                   ]
                 },

--- a/README.md
+++ b/README.md
@@ -19,27 +19,21 @@ See the supporting infrastructure and contracts @ [💎 Ethereum Stack](https://
 
 Casimir is an early work-in-progress – we will share more information in the initial version of our [website](apps/website/). In the meantime, feel free to join @ [💬 Casimir Discord](https://discord.com/invite/Vy2b3gSZx8) if you want to say hello and discuss the project.
 
-## Setup
+## 💻 Development
 
 Get started contributing to Casimir.
 
 ### Prerequisites
 
-Make sure your development environment has the necessary prerequisites.
+Make sure your development environment has these prerequisites.
 
 1. [Node.js (v16.x)](https://nodejs.org/en/download/) – we use [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions.
 
-2. [VSCode](https://code.visualstudio.com/) – you could also use another editor, but this helps us guarantee linter/formatter features.
+2. [AWS CLI (v2.x)](https://aws.amazon.com/cli/) – create an [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) named `consensus-networks-dev`.
 
-3. [Volar VSCode Extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) – Vue 3 language support (turn off vetur and ts/js language features if you have problems arising from conflicts).
+3. [SAM CLI (v1.x)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) - tool for mocking backend services locally.
 
-4. [Eslint VSCode Extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) – linter and formatter.
-
-5. [AWS CLI](https://aws.amazon.com/cli/) – create an [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) named `consensus-networks-dev`.
-
-6. [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) - optional tool for local mocking backend services.
-
-### Install
+### Setup
 
 Clone the repository, checkout a new branch from develop, and install all dependencies.
 
@@ -50,9 +44,9 @@ git checkout -b feature/stake-button develop
 npm install
 ```
 
-> This will install all workspace dependencies for this monorepo.
+> 🚩 This will install all workspace dependencies for this monorepo.
 
-## 💻 Development
+### Serve
 
 You can get up and running without configuration. You can also mock local backend changes and customize your environment.
 
@@ -62,7 +56,7 @@ You can get up and running without configuration. You can also mock local backen
     npm run dev
     ```
 
-    > This will also preconfigure the application environment with the AWS credentials for the `consensus-networks-dev` profile (set PROFILE="some-other-name" in .env if you want to override).
+    > 🚩 This will also preconfigure the application environment with the AWS credentials for the `consensus-networks-dev` profile (set PROFILE="some-other-name" in .env if you want to override).
 
 2. For fullstack changes – run the development server and mock the local backend services.
 
@@ -70,7 +64,7 @@ You can get up and running without configuration. You can also mock local backen
     npm run dev --mock
     ```
 
-    > You will need the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) for local mocking.
+    > 🚩 You will need the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) for local mocking.
 
 3. Optionally customize and override the defaults for your *local development environment* by creating a `.env` file in the project root and adding values for common variables.
 
@@ -80,6 +74,40 @@ You can get up and running without configuration. You can also mock local backen
     # Override the environment stage name (defaults to "dev")
     STAGE="sandbox"
     ```
+
+### Layout
+
+Code is organized into work directories (apps, services, infrastructure, etc.) Individual packages are managed from the project root with [workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces). 
+
+```tree
+├── .github/ (workflows and issue templates)
+|   └── workflows/ (gh actions workflows)
+├── apps/ (frontend apps)
+|   └── website/ (main web app)
+├── infrastructure/ (deployment resources)
+|   └── cdk/ (aws stacks)
+├── common/ (shared code)
+|   └── lib/ (general utilities)
+├── content/ (static code and text)
+|   └── emails/ (pinpoint templates)
+├── scripts/ (devops and build scripts)
+|   └── local/ (mock and serve tasks)
+├── services/ (backend services)
+|   └── users/ (users lambda api)
+└── package.json (project npm scripts)
+```
+
+> 🚩 While developing, most likely, you shouldn't have to change into any subdirectories to run commands.
+
+### Editor
+
+Feel free to use any editor, but here's a configuration that works with this codebase.
+
+1. [VSCode](https://code.visualstudio.com/) – you could also use another editor, but this helps us guarantee linter/formatter features.
+
+2. [Volar VSCode Extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) – Vue 3 language support (turn off vetur and ts/js language features if you have problems arising from conflicts).
+
+3. [Eslint VSCode Extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) – linter and formatter.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Make sure your development environment has the necessary prerequisites.
 
 4. [Eslint VSCode Extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) – linter and formatter.
 
-> *Note: AWS credentials usage is not yet set up, but we will require the AWS CLI when it is.*
-<br /><br />
-*5. [AWS CLI](https://aws.amazon.com/cli/) – create an [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) named `consensus-networks-dev`.*
+5. [AWS CLI](https://aws.amazon.com/cli/) – create an [AWS profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) named `consensus-networks-dev`.
+
+6. [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) - optional tool for local mocking backend services.
 
 ### Install
 
@@ -54,13 +54,23 @@ npm install
 
 ## 💻 Development
 
-Run the development server for the default application ([apps/website](apps/website/) in this case) and backend services.
+For local development, you have a few options:
+
+1. For frontend changes – run the development server and use the `dev` stage backend services.
+
+    ```zsh
+    npm run dev
+    ```
+
+    > This will also preconfigure the application environment with the AWS credentials for the `consensus-networks-dev` profile (set PROFILE="some-other-name" in .env if you want to override).
+
+2. For fullstack changes – Run the development server and live-mock the local backend services.
 
 ```zsh
-npm run dev
+npm run dev:mock
 ```
 
-> This will also preconfigure the application environment with the AWS credentials for the `consensus-networks-dev` profile.
+> You will need the SAM CLI to run this.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ You can get up and running without configuration. You can also mock local backen
     npm run dev --mock
     ```
 
-    > You will need the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) for live-mocking.
+    > You will need the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) for local mocking.
 
-3. Optionally customize your local development environment by create a `.env` and adding overrides for common variables.
+3. Optionally customize and override the defaults for your *local development environment* by creating a `.env` file in the project root and adding values for common variables.
 
     ```zsh
+    # Override AWS profile name (defaults to "consensus-networks-dev")
     PROFILE="some-other-aws-name"
+    # Override the environment stage name (defaults to "dev")
     STAGE="sandbox"
     ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can get up and running without configuration. You can also mock local backen
     STAGE="sandbox"
     ```
 
-### Layout
+## Layout
 
 Code is organized into work directories (apps, services, infrastructure, etc.) Individual packages are managed from the project root with [workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces). 
 
@@ -99,7 +99,7 @@ Code is organized into work directories (apps, services, infrastructure, etc.) I
 
 > 🚩 While developing, most likely, you shouldn't have to change into any subdirectories to run commands.
 
-### Editor
+## Editor
 
 Feel free to use any editor, but here's a configuration that works with this codebase.
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,11 @@ You can get up and running without configuration. You can also mock local backen
 
     > This will also preconfigure the application environment with the AWS credentials for the `consensus-networks-dev` profile (set PROFILE="some-other-name" in .env if you want to override).
 
-2. For fullstack changes – run the development server and live-mock the local backend services.
+2. For fullstack changes – run the development server and mock the local backend services.
 
     ```zsh
     npm run dev --mock
     ```
-
-    The current mockable backend services include:
-    - [Users Rest API](services/users)
 
     > You will need the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) for live-mocking.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install
 
 ## 💻 Development
 
-For local development, you have a few options:
+You can get up and running without configuration. You can also mock local backend changes and customize your environment.
 
 1. For frontend changes – run the development server and use the `dev` stage backend services.
 
@@ -64,13 +64,23 @@ For local development, you have a few options:
 
     > This will also preconfigure the application environment with the AWS credentials for the `consensus-networks-dev` profile (set PROFILE="some-other-name" in .env if you want to override).
 
-2. For fullstack changes – Run the development server and live-mock the local backend services.
+2. For fullstack changes – run the development server and live-mock the local backend services.
 
-```zsh
-npm run dev:mock
-```
+    ```zsh
+    npm run dev --mock
+    ```
 
-> You will need the SAM CLI to run this.
+    The current mockable backend services include:
+    - [Users Rest API](services/users)
+
+    > You will need the [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install-mac.html) for live-mocking.
+
+3. Optionally customize your local development environment by create a `.env` and adding overrides for common variables.
+
+    ```zsh
+    PROFILE="some-other-aws-name"
+    STAGE="sandbox"
+    ```
 
 ## License
 

--- a/apps/website/src/composables/slideshow.ts
+++ b/apps/website/src/composables/slideshow.ts
@@ -1,0 +1,21 @@
+import { onMounted, ref } from 'vue'
+
+export default function useSlideshow() {
+    const slideshowProgress = ref(0)
+    const currentSlide = ref(2)
+    onMounted(() => {
+    setInterval(() => {
+        slideshowProgress.value += 0.05
+        if (slideshowProgress.value >= 100) {
+        slideshowProgress.value = 0
+        currentSlide.value =
+            currentSlide.value + 1 !== 3 ? currentSlide.value + 1 : 0
+        }
+    }, 0.00000005)
+    })
+
+    return {
+        slideshowProgress,
+        currentSlide
+    }
+}

--- a/apps/website/src/composables/users.ts
+++ b/apps/website/src/composables/users.ts
@@ -1,0 +1,40 @@
+export default function useUsers() {
+
+    /**
+     * Sign up a new user for email notifications
+     * 
+     * @param {string} email - The email address of the user 
+     * @returns {Promise<Response>} - The response from the signup user API route
+     */
+    async function signupUser(email: string): Promise<Response> {
+        const requestOptions = {
+            method: 'POST',
+            headers: { 
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ email })
+        }
+
+        console.log(requestOptions)
+        const usersBaseUrl = getUsersBaseUrl()
+        return await fetch(`${usersBaseUrl}/users/signup`, requestOptions)
+    }
+
+    /**
+     * Get the users base url for the current environment
+     * 
+     * @returns {string} The base URL for the users API
+     */
+    function getUsersBaseUrl(): string {
+        if (import.meta.env.PUBLIC_MOCK_ENABLED) {
+            return `http://localhost:${import.meta.env.PUBLIC_USERS_PORT}`
+        } else {
+            return `https://users.${import.meta.env.PUBLIC_STAGE || 'dev'}.casimir.co`
+        }
+    }
+
+    return {
+        signupUser
+    }
+}
+

--- a/apps/website/src/env.d.ts
+++ b/apps/website/src/env.d.ts
@@ -13,8 +13,8 @@ declare module '*.vue' {
   export default component
 }
 
-declare type SignupResponse = {
+declare type APIGatewayResponse = {
   headers?: any
   statusCode: number
-  body: [UpdateEndpointCommandOutput, SendMessagesCommandOutput] | Error
+  body: [UpdateEndpointCommandOutput, SendMessagesCommandOutput] | any | Error
 }

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -6,6 +6,8 @@ import '@/index.css'
 import { createRouter, createWebHistory } from 'vue-router'
 import routes from '~pages'
 
+console.log('Local mocking is', import.meta.env.PUBLIC_MOCK ? 'enabled' : 'disabled')
+
 const app = createApp(App)
 const router = createRouter({
   history: createWebHistory(),

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -6,7 +6,8 @@ import '@/index.css'
 import { createRouter, createWebHistory } from 'vue-router'
 import routes from '~pages'
 
-console.log('Local mocking is', import.meta.env.PUBLIC_MOCK ? 'enabled' : 'disabled')
+console.log('Creating app...', import.meta.env)
+console.log('Local mocking is', import.meta.env.PUBLIC_MOCK_ENABLED ? 'enabled' : 'disabled')
 
 const app = createApp(App)
 const router = createRouter({

--- a/apps/website/src/pages/index/index.vue
+++ b/apps/website/src/pages/index/index.vue
@@ -18,9 +18,9 @@ async function onSubmit() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email: email.value }),
   }
-  const baseUrl = import.meta.env.PROD
-    ? 'https://w47s4clcwi.execute-api.us-east-2.amazonaws.com/prod'
-    : 'http://localhost:4000'
+
+  const baseUrl = getBaseUrl()
+
   try {
     email.value = ''
     // Change success message display to show
@@ -34,6 +34,15 @@ async function onSubmit() {
   }
 }
 
+function getBaseUrl() {
+  // Todo replace with custom subdomain for simplicity
+  if (import.meta.env.PROD) {
+    return 'https://w47s4clcwi.execute-api.us-east-2.amazonaws.com/prod'
+  } else {
+    return import.meta.env.PUBLIC_MOCK ? import.meta.env.PUBLIC_USERS_MOCK : 'https://37sgxzp20c.execute-api.us-east-2.amazonaws.com/prod'
+  }
+}
+
 const hideMessages = () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -43,13 +52,14 @@ const hideMessages = () => {
   document.getElementById('invalid-message').style.display = 'none'
 }
 
-// Create function that does email validation
+/**
+ * 
+ * 
+ * @param email {string} email string from user input to validate
+ */
 function validateEmail(email: string) {
-  
   const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-  const valid = re.test(String(email).toLowerCase())
-  console.log('valid :>> ', valid)
-  return valid
+  return re.test(String(email).toLowerCase())
 }
 
 const slideshowProgress = ref(0)
@@ -164,9 +174,7 @@ onMounted(() => {
         v-if="currentSlide === 1"
         class="flex flex-wrap slideshow"
       >
-        <div
-          class="min-w-[375px] w-1/2 pl-[50px] pt-[50px]"
-        >
+        <div class="min-w-[375px] w-1/2 pl-[50px] pt-[50px]">
           <img
             src="/earn.png"
             class="p-[5%] h-[90%] object-cover"
@@ -186,9 +194,7 @@ onMounted(() => {
         v-if="currentSlide === 2"
         class="flex flex-wrap slideshow"
       >
-        <div
-          class="min-w-[375px] w-1/2 pl-[50px] pt-[50px]"
-        >
+        <div class="min-w-[375px] w-1/2 pl-[50px] pt-[50px]">
           <img
             src="/earn3.png"
             class="p-[5%] h-[90%] object-cover"
@@ -310,13 +316,11 @@ onMounted(() => {
 }
 
 .linear-bg {
-  background: linear-gradient(
-    307.15deg,
-    #f36f38 -3.58%,
-    #f36f38 -3.58%,
-    #f36f38 -3.57%,
-    rgba(243, 111, 56, 0.16) 137.28%
-  );
+  background: linear-gradient(307.15deg,
+      #f36f38 -3.58%,
+      #f36f38 -3.58%,
+      #f36f38 -3.57%,
+      rgba(243, 111, 56, 0.16) 137.28%);
 }
 
 .slideshow {

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -31,7 +31,8 @@ const config: UserConfig = {
       '.tsx',
       '.vue',
     ]
-  }
+  },
+  envPrefix: 'PUBLIC_'
 }
 
 export default config

--- a/cdk-outputs.json
+++ b/cdk-outputs.json
@@ -1,8 +1,0 @@
-{
-  "CasimirUsersStackProd": {
-    "CasimirUsersApiGatewayProdEndpoint97291E6E": "https://w47s4clcwi.execute-api.us-east-2.amazonaws.com/prod/"
-  },
-  "CasimirUsersStackDev": {
-    "CasimirUsersApiGatewayDevEndpoint97291E6E": "https://37sgxzp20c.execute-api.us-east-2.amazonaws.com/prod"
-  }
-}

--- a/cdk-outputs.json
+++ b/cdk-outputs.json
@@ -1,5 +1,8 @@
 {
   "CasimirUsersStackProd": {
     "CasimirUsersApiGatewayProdEndpoint97291E6E": "https://w47s4clcwi.execute-api.us-east-2.amazonaws.com/prod/"
+  },
+  "CasimirUsersStackDev": {
+    "CasimirUsersApiGatewayDevEndpoint97291E6E": "https://37sgxzp20c.execute-api.us-east-2.amazonaws.com/prod"
   }
 }

--- a/infrastructure/cdk/bin/index.ts
+++ b/infrastructure/cdk/bin/index.ts
@@ -1,14 +1,22 @@
 #!/usr/bin/env node
 import 'source-map-support/register'
 import * as cdk from 'aws-cdk-lib'
+import { pascalCase } from '@casimir/lib'
 import { WebsiteStack } from '../lib/website/website-stack'
 import { UsersStack } from '../lib/users/users-stack'
+import { DnsStack } from '../lib/dns/dns-stack'
 
-const project = process.env.PROJECT?.replace(/\b\w/g, c => c.toUpperCase())
-const stage = process.env.STAGE?.replace(/\b\w/g, c => c.toUpperCase())
+const defaultEnv = { account: '257202027633', region: 'us-east-2' }
 
-const defaultEnv  = { account: '257202027633', region: 'us-east-2' }
+if (!process.env.PROJECT || !process.env.STAGE) {
+    console.log('Please specify a project and stage for this CDK stack')
+} else {
+    const project = pascalCase(process.env.PROJECT)
+    const stage = pascalCase(process.env.STAGE)
 
-const app = new cdk.App()
-new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv })
-new UsersStack(app, `${project}UsersStack${stage}`, { env: defaultEnv })
+    const app = new cdk.App()
+    const dnsStack = new DnsStack(app, `${project}DnsStack${stage}`, { env: defaultEnv, project, stage })
+    const { domain, dnsRecords, hostedZone, certificate } = dnsStack
+    new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone, certificate })
+    new UsersStack(app, `${project}UsersStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone, certificate })
+}

--- a/infrastructure/cdk/lib/dns/dns-stack.ts
+++ b/infrastructure/cdk/lib/dns/dns-stack.ts
@@ -1,0 +1,58 @@
+import { Stack, StackProps } from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+import * as route53 from 'aws-cdk-lib/aws-route53'
+
+export interface DnsStackProps extends StackProps {
+  project: string;
+  stage: string;
+}
+
+/**
+ * Class representing the website stack.
+ *
+ * Shortest name:  {@link DnsStack}
+ * Full name:      {@link (DnsStack:class)}
+ */
+export class DnsStack extends Stack {
+
+  public readonly service: string = 'Dns'
+  public readonly domain: string
+  public readonly dnsRecords: Record<string, string>
+  public readonly hostedZone: route53.HostedZone
+
+  /**
+   * DnsStack class constructor.
+   * 
+   * Shortest name:  {@link (DnsStack:constructor)}
+   * Full name:      {@link (DnsStack:constructor)}
+   */
+  constructor(scope: Construct, id: string, props: DnsStackProps) {
+
+    /**
+     * DnsStack class constructor super method.
+     * 
+     * Shortest name:  {@link (DnsStack:constructor:super)}
+     * Full name:      {@link (DnsStack:constructor:super)}
+     */
+    super(scope, id, props)
+
+    const { project, stage } = props
+
+    const domain = 'casimir.co'
+    
+    const dnsRecords = {
+        wildcard: '*',
+        website: 'www',
+        users: 'users'
+    }
+
+    const hostedZone = route53.HostedZone.fromLookup(this, `${project}${this.service}HostedZone${stage}`, {
+      domainName: domain,
+    }) as route53.HostedZone
+
+    this.domain = domain
+    this.dnsRecords = dnsRecords
+    this.hostedZone = hostedZone
+
+  }
+}

--- a/infrastructure/cdk/lib/users/users-stack.ts
+++ b/infrastructure/cdk/lib/users/users-stack.ts
@@ -13,7 +13,6 @@ export interface UsersStackProps extends StackProps {
     domain: string;
     dnsRecords: Record<string, string>;
     hostedZone: route53.HostedZone;
-    certificate: certmgr.DnsValidatedCertificate;
 }
 
 /**

--- a/infrastructure/cdk/lib/users/users-stack.ts
+++ b/infrastructure/cdk/lib/users/users-stack.ts
@@ -3,6 +3,18 @@ import { Construct } from 'constructs'
 import * as apigateway from 'aws-cdk-lib/aws-apigateway'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import * as iam from 'aws-cdk-lib/aws-iam'
+import * as route53targets from 'aws-cdk-lib/aws-route53-targets'
+import * as route53 from 'aws-cdk-lib/aws-route53'
+import * as certmgr from 'aws-cdk-lib/aws-certificatemanager'
+
+export interface UsersStackProps extends StackProps {
+    project: string;
+    stage: string;
+    domain: string;
+    dnsRecords: Record<string, string>;
+    hostedZone: route53.HostedZone;
+    certificate: certmgr.DnsValidatedCertificate;
+}
 
 /**
  * Class representing the users stack.
@@ -12,13 +24,16 @@ import * as iam from 'aws-cdk-lib/aws-iam'
  */
 export class UsersStack extends Stack {
 
+    public readonly service: string = 'Users'
+    public readonly assetPath: string = '../../services/users/dist'
+
     /**
      * UsersStack class constructor.
      * 
      * Shortest name:  {@link (UsersStack:constructor)}
      * Full name:      {@link (UsersStack:constructor)}
      */
-    constructor(scope: Construct, id: string, props?: StackProps) {
+    constructor(scope: Construct, id: string, props: UsersStackProps) {
 
         /**
          * UsersStack class constructor super method.
@@ -28,17 +43,27 @@ export class UsersStack extends Stack {
          */
         super(scope, id, props)
 
-        const project = process.env.PROJECT?.replace(/\b\w/g, c => c.toUpperCase())
-        const stage = process.env.STAGE?.replace(/\b\w/g, c => c.toUpperCase())
-        const service = 'Users'
+        const { project, stage, domain, dnsRecords, hostedZone } = props
 
-        const lambdaHandler = new lambda.Function(this, `${project}${service}Api${stage}`, {
+        // Use casimir.co for prod and dev.casimir.co for dev
+        const serviceDomain = stage === 'Prod' ? domain : [stage.toLowerCase(), domain].join('.')
+    
+        const certificate = new certmgr.DnsValidatedCertificate(this, `${project}${this.service}Cert${stage}`, {
+            domainName: serviceDomain,
+            subjectAlternativeNames: [
+                [dnsRecords.users, serviceDomain].join('.')
+            ],
+            hostedZone,
+            region: 'us-east-2'
+        })
+
+        const lambdaHandler = new lambda.Function(this, `${project}${this.service}Api${stage}`, {
             runtime: lambda.Runtime.NODEJS_14_X,
             handler: 'index.handler',
-            code: lambda.Code.fromAsset('../../services/users/dist'),
+            code: lambda.Code.fromAsset(this.assetPath),
             environment: {
-                PROJECT: process.env.PROJECT as string,
-                STAGE: process.env.STAGE as string
+                PROJECT: project.toLowerCase(),
+                STAGE: stage.toLowerCase()
             },
             timeout: Duration.seconds(25)
         })
@@ -49,21 +74,32 @@ export class UsersStack extends Stack {
         })
 
         lambdaHandler.role?.attachInlinePolicy(
-            new iam.Policy(this, `${project}${service}PinpointPolicy${stage}`, {
+            new iam.Policy(this, `${project}${this.service}PinpointPolicy${stage}`, {
                 statements: [pinpointPolicy]
             })
         )
 
         // Todo update to use new api gateway version when stable
         // https://docs.aws.amazon.com/cdk/api/v2/docs/aws-apigateway-readme.html#apigateway-v2
-        new apigateway.LambdaRestApi(this, `${project}${service}ApiGateway${stage}`, {
-            restApiName: `${project}${service}UsersApiGateway${stage}`,
+        const apiGateway = new apigateway.LambdaRestApi(this, `${project}${this.service}ApiGateway${stage}`, {
+            restApiName: `${project}${this.service}UsersGateway${stage}`,
             handler: lambdaHandler,
+            domainName: {
+                domainName: [dnsRecords.users, serviceDomain].join('.'),
+                certificate
+            },
             defaultCorsPreflightOptions: {
                 allowHeaders: apigateway.Cors.DEFAULT_HEADERS,
                 allowOrigins: apigateway.Cors.ALL_ORIGINS,
                 allowMethods: apigateway.Cors.ALL_METHODS
             }
+        })
+
+        new route53.ARecord(this, `${project}${this.service}DnsARecordApi${stage}`, {
+            recordName: [dnsRecords.users, serviceDomain].join('.'),
+            zone: hostedZone as route53.IHostedZone,
+            target: route53.RecordTarget.fromAlias(new route53targets.ApiGateway(apiGateway)),
+            ttl: Duration.minutes(1),
         })
 
     }

--- a/infrastructure/cdk/test/website.test.ts
+++ b/infrastructure/cdk/test/website.test.ts
@@ -1,14 +1,33 @@
 import * as cdk from 'aws-cdk-lib'
 import { Template } from 'aws-cdk-lib/assertions'
+import { DnsStack } from '../lib/dns/dns-stack'
+import { UsersStack } from '../lib/users/users-stack'
 import { WebsiteStack } from '../lib/website/website-stack'
 
 // Todo actually test something
 test('Website Created', () => {
+
+  const defaultEnv = { account: '257202027633', region: 'us-east-2' }
+  const project = 'Casimir'
+  const stage = 'Test'
+
   const app = new cdk.App()
-  const stack = new WebsiteStack(app, 'MyTestStack')
-  const template = Template.fromStack(stack)
-  console.log(template)
-  // Object.keys(template.findOutputs('*')).forEach(output => {
-  //   expect(output).toBeDefined()
-  // })
+  const dnsStack = new DnsStack(app, `${project}DnsStack${stage}`, { env: defaultEnv, project, stage })
+  const { domain, dnsRecords, hostedZone, certificate } = dnsStack
+  const websiteStack = new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone, certificate })
+  const usersStack = new UsersStack(app, `${project}UsersStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone, certificate })
+
+  const websiteTemplate = Template.fromStack(websiteStack)
+  console.log(websiteTemplate)
+  Object.keys(websiteTemplate.findOutputs('*')).forEach(output => {
+    console.log(output)
+    expect(output).toBeDefined()
+  })
+
+  const usersTemplate = Template.fromStack(usersStack)
+  console.log(usersTemplate)
+  Object.keys(usersTemplate.findOutputs('*')).forEach(output => {
+    console.log(output)
+    expect(output).toBeDefined()
+  })
 })

--- a/infrastructure/cdk/test/website.test.ts
+++ b/infrastructure/cdk/test/website.test.ts
@@ -13,9 +13,9 @@ test('Website Created', () => {
 
   const app = new cdk.App()
   const dnsStack = new DnsStack(app, `${project}DnsStack${stage}`, { env: defaultEnv, project, stage })
-  const { domain, dnsRecords, hostedZone, certificate } = dnsStack
-  const websiteStack = new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone, certificate })
-  const usersStack = new UsersStack(app, `${project}UsersStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone, certificate })
+  const { domain, dnsRecords, hostedZone } = dnsStack
+  const websiteStack = new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone })
+  const usersStack = new UsersStack(app, `${project}UsersStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone })
 
   const websiteTemplate = Template.fromStack(websiteStack)
   console.log(websiteTemplate)

--- a/infrastructure/cdk/tsconfig.json
+++ b/infrastructure/cdk/tsconfig.json
@@ -20,9 +20,6 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
     "types": ["node", "jest", "mocha"]
   },
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -14,11 +14,7 @@
     "mock": "scripts/cdk/mock -d infrastructure/cdk -s users",
     "deploy": "scripts/cdk/deploy -d infrastructure/cdk",
     "deploy:templates": "scripts/pinpoint/deploy -d content/emails/templates",
-
-    "scriptsample":"(node -e \"if (! require('fs').existsSync('./bin/helpers')){process.exit(1)} \" || npm run setup-helpers) && npm run final-build-step",
-    "devold": "npm run dev --workspace @casimir/website",
-    "argsample": "echo \"The value of --foo is '${npm_config_foo}'\"",
-    "dev": "echo \"The value of --mock is '${npm_config_mock}'\" && (node -e \"if (!process.env.npm_config_mock){process.exit(1)} \" || npm run mock) & npm run dev --workspace @casimir/website",
+    "dev": "(node -e \"if (!\"process.env.npm_config_foo\"){process.exit(1)} \" || npm run mock) & npm run dev --workspace @casimir/website",
 
     "lint": "eslint --ext .vue,.ts ./ --fix",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "mock": "scripts/cdk/mock -d infrastructure/cdk -s users",
     "deploy": "scripts/cdk/deploy -d infrastructure/cdk",
     "deploy:templates": "scripts/pinpoint/deploy -d content/emails/templates",
-    "dev": "npm run mock & npm run dev --workspace @casimir/website",
+
+    "scriptsample":"(node -e \"if (! require('fs').existsSync('./bin/helpers')){process.exit(1)} \" || npm run setup-helpers) && npm run final-build-step",
+    "devold": "npm run dev --workspace @casimir/website",
+    "argsample": "echo \"The value of --foo is '${npm_config_foo}'\"",
+    "dev": "echo \"The value of --mock is '${npm_config_mock}'\" && (node -e \"if (!process.env.npm_config_mock){process.exit(1)} \" || npm run mock) & npm run dev --workspace @casimir/website",
+
     "lint": "eslint --ext .vue,.ts ./ --fix",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:push": "scripts/actions/test -w push",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,9 @@
     "services/*"
   ],
   "scripts": {
-    "config": "scripts/aws/configure",
-    "premock": "npm run config & npm run build --workspace @casimir/users",
-    "mock": "scripts/cdk/mock -d infrastructure/cdk -s users",
     "deploy": "scripts/cdk/deploy -d infrastructure/cdk",
     "deploy:templates": "scripts/pinpoint/deploy -d content/emails/templates",
-    "dev": "(node -e \"if (!\"process.env.npm_config_foo\"){process.exit(1)} \" || npm run mock) & npm run dev --workspace @casimir/website",
-
+    "dev": "scripts/local/dev",
     "lint": "eslint --ext .vue,.ts ./ --fix",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:push": "scripts/actions/test -w push",

--- a/scripts/actions/test
+++ b/scripts/actions/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Test the GitHub Actions workflows in `.github/workflows`
 #
 # Example:
@@ -9,36 +9,38 @@
 # See https://github.com/nektos/act
 #
 
+# Set default profile
+profile="consensus-networks-dev"
+
+if [ ${PROFILE+x} ]; then
+    echo "PROFILE is set to '$PROFILE'"
+    profile=$PROFILE
+else
+    export PROFILE="$profile"
+    echo "PROFILE is not set, using default profile $PROFILE"
+fi
+
 # Get args
 while getopts w: flag
 do
     case "${flag}" in
-        w) WORKFLOW=${OPTARG};;
+        w) workflow=${OPTARG};;
     esac
 done
 
-# Create local env and secrets files
-touch .secrets
-
-# Set default profile and override if specified in .env 
-PROFILE=consensus-networks-dev
-export $(xargs < .env)
-
-echo "👾 Creating environment for '$PROFILE'"
+echo "👾 Creating environment for '$profile'"
 
 # From .env
-echo SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL >> .secrets
+SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL
 
 # From AWS CLI
-echo AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile $PROFILE) >> .secrets
-echo AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile $PROFILE) >> .secrets
+aws_access_key_id=$(aws configure get aws_access_key_id --profile $profile)
+aws_secret_access_key=$(aws configure get aws_secret_access_key --profile $profile)
 
 # Run selected workflow
-echo "🚀 Running $WORKFLOW workflow"
-act $WORKFLOW \
+echo "🚀 Running $workflow workflow"
+act $workflow \
 --rebuild \
---secret-file .secrets \
+--secret AWS_ACCESS_KEY_ID=$aws_access_key_id \
+--secret AWS_SECRET_ACCESS_KEY=$aws_secret_access_key \
 --verbose
-
-# Remove secrets
-rm -rf .secrets

--- a/scripts/actions/test
+++ b/scripts/actions/test
@@ -9,17 +9,6 @@
 # See https://github.com/nektos/act
 #
 
-# Set default profile
-profile="consensus-networks-dev"
-
-if [ ${PROFILE+x} ]; then
-    echo "PROFILE is set to '$PROFILE'"
-    profile=$PROFILE
-else
-    export PROFILE="$profile"
-    echo "PROFILE is not set, using default profile $PROFILE"
-fi
-
 # Get args
 while getopts w: flag
 do
@@ -28,19 +17,45 @@ do
     esac
 done
 
-echo "👾 Creating environment for '$profile'"
+if [ -z "$workflow" ]; then
+    echo "⚠️ Workflow is not set – please specify as -w workflow-to-test (i.e. -w push)"
+    exit 1
+fi
+
+# Get variables from root .env
+export $(xargs < .env)
+
+if [ -z "$SLACK_WEBHOOK_URL" ]; then
+    echo "⚠️ SLACK_WEBHOOK_URL is not set – please set a SLACK_WEBHOOK_URL in the root .env file"
+    exit 1
+fi
 
 # From .env
 SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL
 
-# From AWS CLI
-aws_access_key_id=$(aws configure get aws_access_key_id --profile $profile)
-aws_secret_access_key=$(aws configure get aws_secret_access_key --profile $profile)
+# Set default profile
+profile="consensus-networks-dev"
+
+if [ ${PROFILE+x} ]; then
+    echo "PROFILE is set to '$PROFILE'"
+    profile=$PROFILE
+else
+    export PROFILE="$profile"
+    echo "PROFILE is not set, using default profile '$PROFILE'"
+fi
+
+export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile $profile)
+export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile $profile)
+
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "🙈 Could not find AWS credentials for profile '$profile'"
+    exit 1
+fi
 
 # Run selected workflow
 echo "🚀 Running $workflow workflow"
 act $workflow \
 --rebuild \
---secret AWS_ACCESS_KEY_ID=$aws_access_key_id \
---secret AWS_SECRET_ACCESS_KEY=$aws_secret_access_key \
+--secret AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+--secret AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
 --verbose

--- a/scripts/aws/configure
+++ b/scripts/aws/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Configure process for a specific AWS profile
 #
 # Example:

--- a/scripts/aws/configure
+++ b/scripts/aws/configure
@@ -3,38 +3,41 @@
 #
 # Example:
 #
-#    scripts/aws/configure -p profile-to-use -s stage-to-use
+#    scripts/aws/configure
 #
 # Further information:
 # See https://docs.aws.amazon.com/
 #
 
-# Set defaults
+# Get variables from root .env
+export $(xargs < .env)
+
+# Set default profile
 profile="consensus-networks-dev"
-stage="dev"
 
-# Override PROFILE from .env if set
-export $(xargs < .env)
-if [ -n "$PROFILE" ]; then
+if [ ${PROFILE+x} ]; then
+    echo "PROFILE is set to '$PROFILE'"
     profile=$PROFILE
+else
+    export PROFILE="$profile"
+    echo "PROFILE is not set, using default profile '$PROFILE'"
 fi
 
-# Override STAGE from .env if set
-export $(xargs < .env)
-if [ -n "$STAGE" ]; then
-    stage=$STAGE
+# Override project if PROJECT is set in .env
+if [ ${PROJECT+x} ]; then
+    echo "PROJECT is set to '$PROJECT'"
+else
+    export PROJECT="casimir"
+    echo "PROJECT is not set, using default project '$PROJECT'"
 fi
 
-# Override with -p arg from command line if set
-while getopts p:s: flag
-do
-    case "${flag}" in
-        p) profile=${OPTARG};;
-        s) stage=${OPTARG};;
-    esac
-done
-
-echo "👾 Configuring '$stage' environment for '$profile'"
+# Override stage if STAGE is set in .env
+if [ ${STAGE+x} ]; then
+    echo "STAGE is set to '$STAGE'"
+else
+    export STAGE="dev"
+    echo "STAGE is not set, using default stage $STAGE"
+fi
 
 export AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile $profile)
 export AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key --profile $profile)

--- a/scripts/cdk/deploy
+++ b/scripts/cdk/deploy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Deploy CDK app to a cluster
 #
 # Example:
@@ -6,29 +6,37 @@
 #    scripts/cdk/deploy -d ./path/to/cdk-directory
 #
 # Further information:
-# See https://docs.aws.amazon.com/cdk/api/v2/docs/aws-construct-library.html
+# See https://docs.aws.amazon.com/cdk/api/v2/
 #
 
 # Get args
 while getopts d: flag
 do
     case "${flag}" in
-        d) DIRECTORY=${OPTARG};;
+        d) directory=${OPTARG};;
     esac
 done
 
-if [ -z "$(ls -A $DIRECTORY)" ]; then
-    echo "⚠️ CDK source directory is empty"
-else
-    echo "🚀 Deploying CDK app"
-    OUT_DIR=$(pwd)/cdk-outputs.json
-    cd $DIRECTORY
-    npx cdk bootstrap
-    npx cdk synth
-    npx cdk diff
-    # Log to file and display in console
-    npx cdk deploy '**' --require-approval never --outputs-file $OUT_DIR --verbose --debug --force
+if [ -z "$directory" ]; then
+    echo "⚠️ CDK source directory is not set – please specify as -d ./path/to/cdk-directory"
+    exit 1
 fi
+
+if [ -z "$(ls -A $directory)" ]; then
+    echo "⚠️ CDK source directory is empty – please make sure you have a valid CDK source directory"
+    exit 1
+fi
+
+echo "🚀 Deploying CDK app"
+OUT_DIR=$(pwd)/cdk-outputs.json
+cd $directory
+
+# Deploy CDK app
+npx cdk bootstrap
+npx cdk synth
+npx cdk diff
+# Log outputs for parsing in workflow
+npx cdk deploy '**' --require-approval never --outputs-file $OUT_DIR --force
 
 
 

--- a/scripts/cdk/destroy
+++ b/scripts/cdk/destroy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Destroy the CDK app from the CDK cluster
 #
 # Example:
@@ -6,21 +6,28 @@
 #    scripts/cdk/destroy -d ./path/to/cdk-directory
 #
 # Further information:
-# See https://github.com/nektos/act
+# See https://docs.aws.amazon.com/cdk/api/v2/
 #
 
 # Get args
 while getopts d: flag
 do
     case "${flag}" in
-        d) DIRECTORY=${OPTARG};;
+        d) directory=${OPTARG};;
     esac
 done
 
-if [ -z "$(ls -A $DIRECTORY)" ]; then
-    echo "⚠️ CDK source directory is empty"
-else
-    cd $DIRECTORY
-    npm install
-    npx cdk destroy '**' --force --require-approval never
+if [ -z "$directory" ]; then
+    echo "⚠️ CDK source directory is not set – please specify as -d ./path/to/cdk-directory"
+    exit 1
 fi
+
+if [ -z "$(ls -A $directory)" ]; then
+    echo "⚠️ CDK source directory is empty – please make sure you have a valid CDK source directory"
+    exit 1
+fi
+
+echo "🔥 Destroying CDK app"
+cd $directory
+npm install
+npx cdk destroy '**' --force --require-approval never

--- a/scripts/cdk/mock
+++ b/scripts/cdk/mock
@@ -1,52 +1,94 @@
-#!/bin/sh
+#!/bin/bash
 # Mock AWS resources and run tests in localstack
 #
 # Example:
 #
-#    scripts/cdk/mock -d ./path/to/cdk-directory -s name-of-service (i.e. users)
+#    scripts/cdk/mock -d ./path/to/cdk-directory -s string-of-services (i.e. -s users,analytics)
 #
 # Further information:
-# See https://localstack.cloud/
+# See https://docs.aws.amazon.com/cdk/api/v2/
 #
-
-# Set defaults
-profile="consensus-networks-dev"
-
-# Override PROFILE from .env if set
-export $(xargs < .env)
-if [ -n "$PROFILE" ]; then
-    profile=$PROFILE
-fi
 
 # Get args
 while getopts d:s: flag
 do
     case "${flag}" in
-        d) DIRECTORY=${OPTARG};;
-        s) SERVICE=${OPTARG};;
+        d) directory=${OPTARG};;
+        s) services=${OPTARG};;
     esac
 done
+
+# Check required args
+if [ -z "$directory" ]; then
+    echo "⚠️ CDK source directory is not set – please specify as -d ./path/to/cdk-directory"
+    exit 1
+fi
+
+if [ -z "$(ls -A $directory)" ]; then
+    echo "⚠️ CDK source directory is empty – please make sure you have a valid CDK source directory"
+    exit 1
+fi
+
+if [ -z "$services" ]; then
+    echo "⚠️ Services to mock are not set – please specify as -s string-of-services (i.e. -s users,analytics)"
+    exit 1
+fi
 
 # Get variables from root .env
 export $(xargs < .env)
 
-if [ -z "$(ls -A $DIRECTORY)" ]; then
-    echo "⚠️ CDK source directory is empty"
+# Set default profile
+profile="consensus-networks-dev"
+
+if [ ${PROFILE+x} ]; then
+    echo "PROFILE is set to '$PROFILE'"
+    profile=$PROFILE
 else
-    echo "🚀 Deploying local CDK app"
-    cd $DIRECTORY
-
-    # Get variables from cdk .env
-    export $(xargs < .env)
-
-    # Get environment variables from .env or process
-    project=$(perl -ne 'print ucfirst' <<< $PROJECT)
-    service=$(perl -ne 'print ucfirst' <<< $SERVICE)
-    stage=$(perl -ne 'print ucfirst' <<< $STAGE)
-
-    # Deploy CDK app
-    npm install
-    npx cdk synth    
-    sam local start-api -p 4000 -t ./cdk.out/${project}${service}Stack${stage}.template.json --profile $profile
-
+    export PROFILE="$profile"
+    echo "PROFILE is not set, using default profile $PROFILE"
 fi
+
+# Override project if PROJECT is set in .env
+if [ ${PROJECT+x} ]; then
+    echo "PROJECT is set to '$PROJECT'"
+else
+    export PROJECT="casimir"
+    echo "PROJECT is not set, using default project $PROJECT"
+fi
+
+# Override stage if STAGE is set in .env
+if [ ${STAGE+x} ]; then
+    echo "STAGE is set to '$STAGE'"
+else
+    export STAGE="dev"
+    echo "STAGE is not set, using default stage $STAGE"
+fi
+
+# Set PascalCase variables
+Project=$(perl -ne 'print ucfirst' <<< $PROJECT)
+Stage=$(perl -ne 'print ucfirst' <<< $STAGE)
+
+echo "🎨 Mocking CDK app"
+cd $directory
+
+# Mock CDK app
+npm install
+npx cdk synth
+
+# Loop over comma-separated string of services
+IFS=',' read -r -a service_list <<< "$services"
+port=4000
+
+for service in "${service_list[@]}"
+do
+    port=$(( port + 1 ))
+    export $(echo PUBLIC_${service^^}_URL=http://localhost:$port)
+    echo "🎨 Mocking service $service on port $port"
+    Service=$(perl -ne 'print ucfirst' <<< $service)
+    sam local start-api \
+    --port $port \
+    --template ./cdk.out/${Project}${Service}Stack${Stage}.template.json \
+    --profile $profile & # Run in parallel
+done
+
+export PUBLIC_MOCK=true

--- a/scripts/local/dev
+++ b/scripts/local/dev
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Select ports for services
+#
+
+echo "npm_config_mock is set to '$npm_config_mock'"
+
+# Configure and expose variables
+source scripts/aws/configure
+export PUBLIC_STAGE=${STAGE}
+
+if [ ${npm_config_mock+x} ]; then
+
+    # Set comma-separated list of services to mock
+    services="users"
+
+    # Loop over comma-separated string of services
+    IFS=',' read -r -a service_list <<< "$services"
+    port=3999
+
+    # Todo kill dynamically
+    kill -9 $(lsof -ti:4000,4001,4002)
+
+    export PUBLIC_MOCK_ENABLED=$npm_config_mock
+
+    for service in "${service_list[@]}"
+    do
+        SERVICE=$(echo $service | tr '[:lower:]' '[:upper:]')
+        port=$(( port + 1 ))
+        export PUBLIC_${SERVICE}_PORT=$port
+    done
+    scripts/local/mock -d infrastructure/cdk -s $services & npm run dev --workspace @casimir/website
+else
+    npm run dev --workspace @casimir/website
+fi

--- a/scripts/local/mock
+++ b/scripts/local/mock
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Mock AWS resources and run tests in localstack
+# Mock AWS api resources from CDK stacks with SAM CLI
 #
 # Example:
 #
-#    scripts/cdk/mock -d ./path/to/cdk-directory -s string-of-services (i.e. -s users,analytics)
+#    scripts/local/mock -d ./path/to/cdk-directory -s string-of-services (i.e. -s users,analytics)
 #
 # Further information:
 # See https://docs.aws.amazon.com/cdk/api/v2/
@@ -34,36 +34,6 @@ if [ -z "$services" ]; then
     exit 1
 fi
 
-# Get variables from root .env
-export $(xargs < .env)
-
-# Set default profile
-profile="consensus-networks-dev"
-
-if [ ${PROFILE+x} ]; then
-    echo "PROFILE is set to '$PROFILE'"
-    profile=$PROFILE
-else
-    export PROFILE="$profile"
-    echo "PROFILE is not set, using default profile $PROFILE"
-fi
-
-# Override project if PROJECT is set in .env
-if [ ${PROJECT+x} ]; then
-    echo "PROJECT is set to '$PROJECT'"
-else
-    export PROJECT="casimir"
-    echo "PROJECT is not set, using default project $PROJECT"
-fi
-
-# Override stage if STAGE is set in .env
-if [ ${STAGE+x} ]; then
-    echo "STAGE is set to '$STAGE'"
-else
-    export STAGE="dev"
-    echo "STAGE is not set, using default stage $STAGE"
-fi
-
 # Set PascalCase variables
 Project=$(perl -ne 'print ucfirst' <<< $PROJECT)
 Stage=$(perl -ne 'print ucfirst' <<< $STAGE)
@@ -73,22 +43,22 @@ cd $directory
 
 # Mock CDK app
 npm install
-npx cdk synth
 
 # Loop over comma-separated string of services
 IFS=',' read -r -a service_list <<< "$services"
-port=4000
 
 for service in "${service_list[@]}"
 do
-    port=$(( port + 1 ))
-    export $(echo PUBLIC_${service^^}_URL=http://localhost:$port)
-    echo "🎨 Mocking service $service on port $port"
+    npm run build --workspace @casimir/$service
+    npx cdk bootstrap
+    npx cdk synth
+    SERVICE=$(echo $service | tr '[:lower:]' '[:upper:]')
+    portname=PUBLIC_${SERVICE}_PORT
+    port=$(echo ${!portname})
+    echo "🎨 Mocking $service service on port $port"
     Service=$(perl -ne 'print ucfirst' <<< $service)
     sam local start-api \
     --port $port \
     --template ./cdk.out/${Project}${Service}Stack${Stage}.template.json \
-    --profile $profile & # Run in parallel
+    --profile $PROFILE & # Run in parallel
 done
-
-export PUBLIC_MOCK=true

--- a/scripts/pinpoint/deploy
+++ b/scripts/pinpoint/deploy
@@ -20,17 +20,48 @@ done
 # Get variables from root .env
 export $(xargs < .env)
 
-# Get environment variables from .env or process
-project=$(perl -ne 'print ucfirst' <<< $PROJECT)
-stage=$(perl -ne 'print ucfirst' <<< $STAGE)
+# Set default profile
+profile="consensus-networks-dev"
+
+if [ ${PROFILE+x} ]; then
+    echo "PROFILE is set to '$PROFILE'"
+    profile=$PROFILE
+else
+    export PROFILE="$profile"
+    echo "PROFILE is not set, using default profile $PROFILE"
+fi
+
+# Override project if PROJECT is set in .env
+if [ ${PROJECT+x} ]; then
+    echo "PROJECT is set to '$PROJECT'"
+else
+    export PROJECT="casimir"
+    echo "PROJECT is not set, using default project $PROJECT"
+fi
+
+# Override stage if STAGE is set in .env
+if [ ${STAGE+x} ]; then
+    echo "STAGE is set to '$STAGE'"
+else
+    export STAGE="dev"
+    echo "STAGE is not set, using default stage $STAGE"
+fi
+
+# Set PascalCase variables
+Project=$(perl -ne 'print ucfirst' <<< $PROJECT)
+Stage=$(perl -ne 'print ucfirst' <<< $STAGE)
 
 # Loop over template folders
 for template_path in $directory/* ; do
     if [ -d "$template_path" ]; then
+    
         # Get current directory name
         template_dir=${template_path##*/}
-        template=$(perl -ne 'print ucfirst' <<< $template_dir)
-        name=$(echo $project$template$stage)
+
+        # Set PascalCase variables
+        Template=$(perl -ne 'print ucfirst' <<< $template_dir)
+
+        name=$(echo $Project$Template$Stage)
         echo "Handling $name template"
 
         raw_html=$(mjml $template_path/index.mjml --config.minify true)
@@ -44,11 +75,11 @@ for template_path in $directory/* ; do
 
         { 
             echo "Attempting to create pinpoint template..."
-            aws pinpoint create-email-template --cli-input-json file://$template_path/template.out/template.json --profile $PROFILE --region us-east-1 && \
+            aws pinpoint create-email-template --cli-input-json file://$template_path/template.out/template.json --profile $profile --region us-east-1 && \
             echo "✅ Successfully created pinpoint template"
             }  ||  {
             echo "Template already exists. Updating pinpoint template..."
-            aws pinpoint update-email-template --cli-input-json file://$template_path/template.out/template.json --profile $PROFILE --region us-east-1 && \
+            aws pinpoint update-email-template --cli-input-json file://$template_path/template.out/template.json --profile $profile --region us-east-1 && \
             echo "✅ Successfully updated pinpoint template"
         }
 

--- a/services/users/api/signup.ts
+++ b/services/users/api/signup.ts
@@ -5,7 +5,7 @@ import {
 } from '@aws-sdk/client-pinpoint'
 import { APIGatewayEvent } from 'aws-lambda'
 import { pascalCase } from '@casimir/lib'
-import { SignupResponse } from '../env'
+import { APIGatewayResponse } from '../env'
 
 const appId = 'e80548536df34c7fb4a58bf64933190e'
 const sourceEmail = 'team@casimir.co'
@@ -16,13 +16,11 @@ const stage = process.env.STAGE || 'dev'
  * Sends a "Welcome" message to a newly signed up user via Pinpoint.
  *
  * @param event - The client request object
- * @returns A promise of SignupResponse with statusCode and body
+ * @returns A promise of APIGatewayResponse with statusCode and body
  *
  */
-export default async function signup(event: APIGatewayEvent): Promise<SignupResponse> {
+export default async function signup(event: APIGatewayEvent): Promise<APIGatewayResponse> {
     console.log('EVENT: ', event)
-
-    console.log('AWS_KEY: ', process.env.AWS_ACCESS_KEY_ID)
 
     const { body } = event
     const { email: destEmail } = JSON.parse(body as string)
@@ -75,21 +73,12 @@ export default async function signup(event: APIGatewayEvent): Promise<SignupResp
         ])
         console.log(data)
         return {
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Headers' : 'Content-Type',
-                'Access-Control-Allow-Methods': 'OPTIONS,POST,PUT,GET,DELETE',
-                'Content-Type': 'application/json'
-            },
             statusCode: 200,
             body: data
         }
     } catch (error) {
         console.log(error)
         return {
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-            },
             statusCode: 500,
             body: error as Error
         }

--- a/services/users/env.d.ts
+++ b/services/users/env.d.ts
@@ -3,8 +3,8 @@ import {
     UpdateEndpointCommandOutput
 } from '@aws-sdk/client-pinpoint'
 
-declare type SignupResponse = {
+declare type APIGatewayResponse = {
     headers?: any
     statusCode: number
-    body: [UpdateEndpointCommandOutput, SendMessagesCommandOutput] | Error
+    body: [UpdateEndpointCommandOutput, SendMessagesCommandOutput] | any | Error
 }

--- a/services/users/index.ts
+++ b/services/users/index.ts
@@ -1,20 +1,29 @@
 import { APIGatewayEvent } from 'aws-lambda'
 import signup from './api/signup'
+import { APIGatewayResponse } from './env'
 
-export const handler = async (event: APIGatewayEvent): Promise<any | void> => {
-  if (event.path === '/api/users/signup') {
-    return await signup(event)
-  } else if (event.path === '/api/ping') {
+const defaultHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Methods': 'OPTIONS,POST,PUT,GET,DELETE',
+  'Content-Type': 'application/json'
+}
+
+export const handler = async (event: APIGatewayEvent): Promise<APIGatewayResponse> => {
+  if (event.path === '/users/signup') {
+    console.log('SIGNUP')
+    const response = await signup(event)
     return {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers' : 'Content-Type',
-        'Access-Control-Allow-Methods': 'OPTIONS,POST,PUT,GET,DELETE',
-        'Content-Type': 'application/json'
-      },
-      statusCode: 200,
+      headers: defaultHeaders,
+      ...response
+    }
+  } else {
+    console.log('NOT SIGNUP')
+    return {
+      headers: defaultHeaders,
+      statusCode: 404,
       body: {
-        message: 'pong'
+        message: 'Requested route does not exist'
       }
     }
   }


### PR DESCRIPTION
Makes the basic setup unreliant on any externally-installed CLI tool and moves mocking behind a flag.

**Basic setup**
Run `npm run dev` from project root. Uses the AWS-deployed `dev` stage endpoints service endpoints by default in the Vue app, so no upfront config is necessary. This stage can be overridden in .env with STAGE variable.

**Mocking setup**
Install the SAM CLI on your machine and then run `npm run dev --mock`. Uses the local `dev` stage endpoints (which you may even prefer to override with `prod` to do things like reference production static resources (email templates, for example) and pass them into your local development for testing. SAM CLI can crawl our AWS CDK stacks to find and serve API Gateway endpoints. We pass in environment variables to the frontend development server (process.env.PUBLIC_MOCK, process.env.PUBLIC_{"api-name")_URL to switch to local endpoint URLs. 

Wrote more about the setup in the [README.md](https://github.com/consensusnetworks/casimir/tree/enhancement/config-defaults#setup). More about the SAM/CDK mocking integration [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-cdk-getting-started.html), and our script using the CLI is [here](https://github.com/consensusnetworks/casimir/blob/enhancement/config-defaults/scripts/cdk/mock).

Lastly just moved AWS-deployed API endpoints behind our custom domain for clean reference based on the current environment's stage.
