### PR TITLE
Add basic checks for bot activity on form

### DIFF
--- a/apps/website/src/pages/index/index.vue
+++ b/apps/website/src/pages/index/index.vue
@@ -14,17 +14,11 @@ const botTrapInput = ref('')
 const timeArrived = ref(new Date().getTime())
 
 async function onSubmit() {
-  const validEmail = validateEmail(email.value)
-  const isBotTrap = botTrapInput.value.length ? true : false
-  if (isBotTrap) return
-  if (!validEmail) {
-    invalidMessage.value.style.display = 'block'
-    return
-  }
+  const isLikelyABot = checkForBot()
+  if (isLikelyABot) return
 
-  const timeNow = new Date().getTime()
-  const timeDiff = timeNow - timeArrived.value
-  if (timeDiff < 3000) {
+  const validEmail = validateEmail(email.value)
+  if (!validEmail) {
     invalidMessage.value.style.display = 'block'
     return
   }
@@ -48,13 +42,32 @@ const hideMessages = () => {
  *
  *
  * @param email {string} email string from user input to validate
+ * @returns {boolean} true if email is valid, false if not
  */
-function validateEmail(email: string) {
+function validateEmail(email: string): boolean {
   const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
   if (email.length < 5 || email.length > 100) {
     return false
   }
   return re.test(String(email).toLowerCase())
+}
+
+/**
+ *
+ *
+ * @returns {boolean} true if bot, false if not
+ */
+function checkForBot(): boolean {
+  const botTrap = botTrapInput.value.length ? true : false
+  if (botTrap) return true
+  const timeNow = new Date().getTime()
+  const timeDiff = timeNow - timeArrived.value
+  if (timeDiff < 3000) {
+    invalidMessage.value.style.display = 'block'
+    return true
+  } else {
+    return false
+  }
 }
 </script>
 
@@ -122,9 +135,9 @@ function validateEmail(email: string) {
           >
             Please enter a valid email.
           </div>
-          <span class="small-text text-[#667085] pl-[5px]"
-            >We won't spam you. We promise.</span
-          >
+          <span class="small-text text-[#667085] pl-[5px]">
+            We won't spam you. We promise.
+          </span>
         </form>
       </div>
       <div class="min-w-[370px] w-1/2 h-[500px] relative overflow-hidden">

--- a/apps/website/src/pages/index/index.vue
+++ b/apps/website/src/pages/index/index.vue
@@ -10,13 +10,24 @@ const successMessage: Ref = ref<HTMLDivElement>()
 const invalidMessage: Ref = ref<HTMLDivElement>()
 
 const email = ref('')
+const botTrapInput = ref('')
+const timeArrived = ref(new Date().getTime())
+
 async function onSubmit() {
   const validEmail = validateEmail(email.value)
+  const isBotTrap = botTrapInput.value.length ? true : false
+  if (isBotTrap) return
   if (!validEmail) {
     invalidMessage.value.style.display = 'block'
     return
   }
-  console.log('validEmail :>> ', validEmail)
+
+  const timeNow = new Date().getTime()
+  const timeDiff = timeNow - timeArrived.value
+  if (timeDiff < 3000) {
+    invalidMessage.value.style.display = 'block'
+    return
+  }
 
   try {
     const newEmail = email.value
@@ -34,12 +45,15 @@ const hideMessages = () => {
 }
 
 /**
- * 
- * 
+ *
+ *
  * @param email {string} email string from user input to validate
  */
 function validateEmail(email: string) {
   const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  if (email.length < 5 || email.length > 100) {
+    return false
+  }
   return re.test(String(email).toLowerCase())
 }
 </script>
@@ -57,19 +71,13 @@ function validateEmail(email: string) {
           <ArrowRightIcon class="w-[15px] h-[20px] mx-2" />
         </button>
         <h1 class="header-text text-[#101828] mt-4 pb-0">
-          <span
-            class="text-[#F36F38]"
-            @click="$router.push('/')"
-          >
+          <span class="text-[#F36F38]" @click="$router.push('/')">
             Your
           </span>
           digital assets
         </h1>
         <h1 class="header-text text-[#101828] mb-4">
-          <span
-            class=" text-[#c4c4c4]"
-            @click="$router.push('/')"
-          >
+          <span class=" text-[#c4c4c4]" @click="$router.push('/')">
             All
           </span>
           in one place
@@ -77,10 +85,7 @@ function validateEmail(email: string) {
         <h1 class="body-text text-[#667085] py-[40px]">
           Non-custodial digital asset management and staking
         </h1>
-        <form
-          novalidate
-          @submit.prevent="onSubmit"
-        >
+        <form novalidate @submit.prevent="onSubmit">
           <div class="mt-10 grid grid-cols-5 gap-2 ">
             <input
               v-model="email"
@@ -88,7 +93,13 @@ function validateEmail(email: string) {
               placeholder="Sign up for early access"
               class="border border-[#D0D5DD] rounded-md px-4 py-2 col-span-3 input-text text-[#F36F38]"
               @click="hideMessages"
-            >
+            />
+            <input
+              v-model="botTrapInput"
+              class="bot-trap"
+              type="text"
+              placeholder="Bot Trap"
+            />
             <button
               type="submit"
               class="bg-[#F36F38] button-text text-white py-2 px-4 rounded-md w-[130px] hover:bg-[#F36F38]/[.75]"
@@ -111,7 +122,9 @@ function validateEmail(email: string) {
           >
             Please enter a valid email.
           </div>
-          <span class="small-text text-[#667085] pl-[5px]">We won't spam you. We promise.</span>
+          <span class="small-text text-[#667085] pl-[5px]"
+            >We won't spam you. We promise.</span
+          >
         </form>
       </div>
       <div class="min-w-[370px] w-1/2 h-[500px] relative overflow-hidden">
@@ -119,56 +132,41 @@ function validateEmail(email: string) {
       </div>
     </div>
 
-    <div class="border w-full p-[50px] bg-[#c4c4c4]/[.5] mt-[100px] min-w-[395px]">
-      <div
-        v-if="currentSlide === 0"
-        class="flex flex-wrap slideshow"
-      >
+    <div
+      class="border w-full p-[50px] bg-[#c4c4c4]/[.5] mt-[100px] min-w-[395px]"
+    >
+      <div v-if="currentSlide === 0" class="flex flex-wrap slideshow">
         <div class="min-w-[375px] w-1/2 pl-[50px] pt-[50px] slideshow">
           <img
             src="/Dashboard.png"
             class="p-[5%] h-[90%] object-cover"
             alt=""
-          >
+          />
         </div>
         <div class="min-w-[375px] w-1/2 pt-[50px] pr-[50px]">
           <h1 class="text-[42px] text-left ">
             <span class="text-[#F36F38] font-extrabold">Manage</span> your
-            assets and earnings across chains. See all of your coins and NFTs
-            in one dashboard.
+            assets and earnings across chains. See all of your coins and NFTs in
+            one dashboard.
           </h1>
         </div>
       </div>
-      <div
-        v-if="currentSlide === 1"
-        class="flex flex-wrap slideshow"
-      >
+      <div v-if="currentSlide === 1" class="flex flex-wrap slideshow">
         <div class="min-w-[375px] w-1/2 pl-[50px] pt-[50px]">
-          <img
-            src="/earn.png"
-            class="p-[5%] h-[90%] object-cover"
-            alt=""
-          >
+          <img src="/earn.png" class="p-[5%] h-[90%] object-cover" alt="" />
         </div>
         <div class="min-w-[375px] w-1/2 pt-[50px] pr-[50px]">
           <h1 class="text-[42px] text-left ">
             <span class="text-[#F36F38] font-extrabold">Earn</span> by staking
-            your assets to high performing validators. Participate in
-            liquidity pools. Help keep staking decentralized with a strong set
-            of independent validators.
+            your assets to high performing validators. Participate in liquidity
+            pools. Help keep staking decentralized with a strong set of
+            independent validators.
           </h1>
         </div>
       </div>
-      <div
-        v-if="currentSlide === 2"
-        class="flex flex-wrap slideshow"
-      >
+      <div v-if="currentSlide === 2" class="flex flex-wrap slideshow">
         <div class="min-w-[375px] w-1/2 pl-[50px] pt-[50px]">
-          <img
-            src="/earn3.png"
-            class="p-[5%] h-[90%] object-cover"
-            alt=""
-          >
+          <img src="/earn3.png" class="p-[5%] h-[90%] object-cover" alt="" />
         </div>
         <div class="min-w-[375px] w-1/2 pt-[50px] pr-[50px]">
           <h1 class="text-[42px] text-left ">
@@ -193,21 +191,10 @@ function validateEmail(email: string) {
           target="_blank"
           class="w-[25px]"
         >
-          <img
-            src="/twitter.svg"
-            alt=""
-            class="border"
-          >
+          <img src="/twitter.svg" alt="" class="border" />
         </a>
-        <a
-          href="https://discord.gg/hkJD9gnN"
-          target="_blank"
-          class="w-[25px]"
-        >
-          <img
-            src="/discord.svg"
-            alt=""
-          >
+        <a href="https://discord.gg/hkJD9gnN" target="_blank" class="w-[25px]">
+          <img src="/discord.svg" alt="" />
         </a>
 
         <a
@@ -215,24 +202,18 @@ function validateEmail(email: string) {
           target="_blank"
           class="w-[25px]"
         >
-          <img
-            src="/github.svg"
-            alt=""
-          >
+          <img src="/github.svg" alt="" />
         </a>
       </div>
     </div>
     <div class="flex flex-wrap justify-center">
-      <img
-        src="/CopyrightIcon.svg"
-        alt=""
-        class="w-[20px]"
-      >
+      <img src="/CopyrightIcon.svg" alt="" class="w-[20px]" />
       <a
         href="https://consensusnetworks.com/"
         target="_blank"
         class="text-[#F36F38] mx-4"
-      >Consensus Networks</a>
+        >Consensus Networks</a
+      >
       <span> | All Right Reserved</span>
     </div>
   </div>
@@ -285,11 +266,13 @@ function validateEmail(email: string) {
 }
 
 .linear-bg {
-  background: linear-gradient(307.15deg,
-      #f36f38 -3.58%,
-      #f36f38 -3.58%,
-      #f36f38 -3.57%,
-      rgba(243, 111, 56, 0.16) 137.28%);
+  background: linear-gradient(
+    307.15deg,
+    #f36f38 -3.58%,
+    #f36f38 -3.58%,
+    #f36f38 -3.57%,
+    rgba(243, 111, 56, 0.16) 137.28%
+  );
 }
 
 .slideshow {
@@ -301,6 +284,10 @@ function validateEmail(email: string) {
 }
 
 #invalid-message {
+  display: none;
+}
+
+.bot-trap {
   display: none;
 }
 </style>


### PR DESCRIPTION
@shanejearley Here are the methods I've employed to deter bot sign-ups:
- **Standard email validation** using regex - needs to end in @something.something, for example
- **Hidden `<input>` "bot trap"** - some bots will fill out this input notifying us it is spam while real users will never see it
- **"Time analysis"** - rejects the email if submitted less than 3 seconds from landing on the web page
- **Email Address Length** - if shorter than 5 characters or longer than 100 characters, we reject the email

Check out [this article](https://www.loginradius.com/blog/identity/bot-attacks/) that I drew inspiration from and let me know if you think we should employ any of the other techniques. The other ones I'd consider are:
- **Adding a ReCaptcha** - although when I started down that path it looked like it was for GCP projects only; could be wrong about that. Will investigate further if you think this is worth the slight drawback to user experience. I think there are other "open source" options that we could potentially use as well.
- **Double Opt-In** - may be more trouble than it is worth, but open to doing this

The ones I didn't understand, which could be helpful to hear your interpretation of:
- **6. Hide Target Requests**
- **10. Beware of Cross-Site Request Forgery (CSRF)**

Submitting PR now (copying and pasting this comment from my comment made in issue #33 thread for your convenience)