### PR TITLE
Add initial ETL infrastructure

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
 
     # Skip any pushes with commit flag '(skip deploy)'
     # Comment out for testing
-    if: ${{ !contains(github.event.head_commit.message, '(skip deploy)') }}
+    # if: ${{ !contains(github.event.head_commit.message, '(skip deploy)') }}
 
     steps:
       - name: Check out the repo

--- a/infrastructure/cdk/bin/index.ts
+++ b/infrastructure/cdk/bin/index.ts
@@ -5,6 +5,7 @@ import { pascalCase } from '@casimir/lib'
 import { WebsiteStack } from '../lib/website/website-stack'
 import { UsersStack } from '../lib/users/users-stack'
 import { DnsStack } from '../lib/dns/dns-stack'
+import { EtlStack } from '../lib/etl/etl-stack'
 
 const defaultEnv = { account: '257202027633', region: 'us-east-2' }
 
@@ -17,6 +18,7 @@ if (!process.env.PROJECT || !process.env.STAGE) {
     const app = new cdk.App()
     const dnsStack = new DnsStack(app, `${project}DnsStack${stage}`, { env: defaultEnv, project, stage })
     const { domain, dnsRecords, hostedZone } = dnsStack
-    new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone })
+    new EtlStack(app, `${project}EtlStack${stage}`, { env: defaultEnv, project, stage })
     new UsersStack(app, `${project}UsersStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone })
+    new WebsiteStack(app, `${project}WebsiteStack${stage}`, { env: defaultEnv, project, stage, domain, dnsRecords, hostedZone })
 }

--- a/infrastructure/cdk/lib/etl/etl-stack.ts
+++ b/infrastructure/cdk/lib/etl/etl-stack.ts
@@ -2,9 +2,6 @@ import { Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as glue from '@aws-cdk/aws-glue-alpha'
-// import * as glue from 'aws-cdk-lib/aws-glue'
-// import * as lambda from 'aws-cdk-lib/aws-lambda'
-// import { S3EventSource } from 'aws-cdk-lib/aws-lambda-event-sources'
 
 export interface EtlStackProps extends StackProps {
     project: string;
@@ -25,8 +22,18 @@ export class EtlStack extends Stack {
             databaseName: databaseName.toLowerCase()
         })
 
-        const eventBucket = new s3.Bucket(this, `${project}${this.service}EventBucket${stage}`)
-        const aggBucket = new s3.Bucket(this, `${project}${this.service}AggBucket${stage}`)
+        const eventBucket = new s3.Bucket(this, `${project}${this.service}EventBucket${stage}`, {
+            bucketName: `${project}-${this.service}-event-bucket-${stage}`.toLowerCase(),
+        })
+
+        const aggBucket = new s3.Bucket(this, `${project}${this.service}AggBucket${stage}`, {
+            bucketName: `${project}-${this.service}-agg-bucket-${stage}`.toLowerCase(),
+        })
+
+        // Output bucket for Athena queries
+        new s3.Bucket(this, `${project}${this.service}OutputBucket${stage}`, {
+            bucketName: `${project}-${this.service}-output-bucket-${stage}`.toLowerCase(),
+        })
 
         const eventTableName = `${project}_${this.service}_Event_Table_${stage}`
         new glue.Table(this, `${project}${this.service}EventTable${stage}`, {
@@ -112,16 +119,5 @@ export class EtlStack extends Stack {
             ],
             dataFormat: glue.DataFormat.JSON,
         })
-
-        // Todo remove after reference commit
-        // const processor = new lambda.Function(this, `${project}${this.service}Processor${stage}`, {
-        //   runtime: lambda.Runtime.NODEJS_14_X,
-        //   handler: 'index.handler',
-        //   code: lambda.Code.fromAsset('../../services/processor')
-        // })
-
-        // processor.addEventSource(new S3EventSource(eventBucket, {
-        //   events: [s3.EventType.OBJECT_CREATED]
-        // }))
     }
 }

--- a/infrastructure/cdk/lib/etl/etl-stack.ts
+++ b/infrastructure/cdk/lib/etl/etl-stack.ts
@@ -1,0 +1,127 @@
+import { Stack, StackProps } from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+import * as s3 from 'aws-cdk-lib/aws-s3'
+import * as glue from '@aws-cdk/aws-glue-alpha'
+// import * as glue from 'aws-cdk-lib/aws-glue'
+// import * as lambda from 'aws-cdk-lib/aws-lambda'
+// import { S3EventSource } from 'aws-cdk-lib/aws-lambda-event-sources'
+
+export interface EtlStackProps extends StackProps {
+    project: string;
+    stage: string;
+}
+
+export class EtlStack extends Stack {
+
+    public readonly service: string = 'Etl'
+
+    constructor(scope: Construct, id: string, props: EtlStackProps) {
+        super(scope, id, props)
+
+        const { project, stage } = props
+
+        const databaseName = `${project}_${this.service}_Database_${stage}`
+        const database = new glue.Database(this, `${project}${this.service}Database${stage}`, {
+            databaseName: databaseName.toLowerCase()
+        })
+
+        const eventBucket = new s3.Bucket(this, `${project}${this.service}EventBucket${stage}`)
+        const aggBucket = new s3.Bucket(this, `${project}${this.service}AggBucket${stage}`)
+
+        const eventTableName = `${project}_${this.service}_Event_Table_${stage}`
+        new glue.Table(this, `${project}${this.service}EventTable${stage}`, {
+            database: database,
+            tableName: eventTableName.toLowerCase(),
+            bucket: eventBucket,
+            columns: [
+                {
+                    name: 'type',
+                    type: glue.Schema.STRING,
+                    comment: 'The type of event'
+                },
+                {
+                    name: 'datestring',
+                    type: glue.Schema.TIMESTAMP,
+                    comment: 'The datestring (MM-DD-YYYY) of the event'
+                },
+                {
+                    name: 'address',
+                    type: glue.Schema.STRING,
+                    comment: 'The address that initiated the event'
+                },
+                {
+                    name: 'staked_candidate',
+                    type: glue.Schema.STRING,
+                    comment: 'The name of the candidate that received the stake action event'
+                },
+                {
+                    name: 'staked_amount',
+                    type: glue.Schema.BIG_INT,
+                    comment: 'The amount staked or unstaked in the stake action event'
+                },
+                {
+                    name: 'staked_duration',
+                    type: glue.Schema.INTEGER,
+                    comment: 'The duration of the stake action event'
+                },
+                {
+                    name: 'auto_stake',
+                    type: glue.Schema.BOOLEAN,
+                    comment: 'The compounding selection of the stake action event'
+                },
+            ],
+            dataFormat: glue.DataFormat.JSON,
+        })
+
+        const aggTableName = `${project}_${this.service}_Agg_Table_${stage}`
+        new glue.Table(this, `${project}${this.service}AggTable${stage}`, {
+            database: database,
+            tableName: aggTableName.toLowerCase(),
+            bucket: aggBucket,
+            columns: [
+                {
+                    name: 'type',
+                    type: glue.Schema.STRING,
+                    comment: 'The type of aggregate (e.g. wallet, contract, etc.)'
+                },
+                {
+                    name: 'address',
+                    type: glue.Schema.STRING,
+                    comment: 'The address of the aggregate'
+                },
+                {
+                    name: 'first_staked_at',
+                    type: glue.Schema.TIMESTAMP,
+                    comment: 'The first datestring (MM-DD-YYYY) that a wallet staked'
+                },
+                {
+                    name: 'total_staked_amount',
+                    type: glue.Schema.BIG_INT,
+                    comment: 'The total amount that a wallet has staked'
+                },
+                {
+                    name: 'total_staked_duration',
+                    type: glue.Schema.INTEGER,
+                    comment: 'The total duration that a wallet has staked'
+                },
+                {
+                    name: 'auto_staking',
+                    type: glue.Schema.BOOLEAN,
+                    comment: 'The most recent stake reward compounding selection of a wallet'
+                },
+            ],
+            dataFormat: glue.DataFormat.JSON,
+        })
+
+        // Todo remove after reference commit
+        // const processor = new lambda.Function(this, `${project}${this.service}Processor${stage}`, {
+        //   runtime: lambda.Runtime.NODEJS_14_X,
+        //   handler: 'index.handler',
+        //   code: lambda.Code.fromAsset('../../services/processor')
+        // })
+
+        // processor.addEventSource(new S3EventSource(eventBucket, {
+        //   events: [s3.EventType.OBJECT_CREATED]
+        // }))
+    }
+}

--- a/infrastructure/cdk/package.json
+++ b/infrastructure/cdk/package.json
@@ -21,7 +21,8 @@
         "typescript": "~3.9.7"
     },
     "dependencies": {
-        "aws-cdk-lib": "2.26.0",
+        "@aws-cdk/aws-glue-alpha": "^2.31.0-alpha.0",
+        "aws-cdk-lib": "^2.26.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.16"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,8 @@
     "infrastructure/cdk": {
       "name": "@casimir/cdk",
       "dependencies": {
-        "aws-cdk-lib": "2.26.0",
+        "@aws-cdk/aws-glue-alpha": "^2.31.0-alpha.0",
+        "aws-cdk-lib": "^2.26.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.16"
       },
@@ -100,6 +101,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-glue-alpha": {
+      "version": "2.31.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-glue-alpha/-/aws-glue-alpha-2.31.0-alpha.0.tgz",
+      "integrity": "sha512-JfDyUyBs22PPCblIGtdN8dzG2XSFDhvEDPGumBpXY4RNpcfHFNCiaUxbAKJT/D7+7X5xzuew52r33JhTC9v/Yw==",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.31.0",
+        "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -3568,9 +3581,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.26.0.tgz",
-      "integrity": "sha512-FkTD79U7WRroI3J0fOuIv5DE2uhgIw2F1Z4Fz5XgrMDYB+F4F02/ud6YT+E4vIkUJkb+Jwlh814dDhZ53uYgUw==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.31.0.tgz",
+      "integrity": "sha512-6GvBmHtUx74uffl6kzvTL1bWN2/qPj4oHQj12gtqPifFBbNNrYGjLEeBY6DuidLhg96OoRoFc3lyJoiB/p7BEw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3587,7 +3600,7 @@
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
         "semver": "^7.3.7",
@@ -3679,7 +3692,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -15611,6 +15624,12 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
+    "@aws-cdk/aws-glue-alpha": {
+      "version": "2.31.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-glue-alpha/-/aws-glue-alpha-2.31.0-alpha.0.tgz",
+      "integrity": "sha512-JfDyUyBs22PPCblIGtdN8dzG2XSFDhvEDPGumBpXY4RNpcfHFNCiaUxbAKJT/D7+7X5xzuew52r33JhTC9v/Yw==",
+      "requires": {}
+    },
     "@aws-crypto/ie11-detection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
@@ -16758,11 +16777,12 @@
     "@casimir/cdk": {
       "version": "file:infrastructure/cdk",
       "requires": {
+        "@aws-cdk/aws-glue-alpha": "*",
         "@types/jest": "^27.5.2",
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.35",
         "aws-cdk": "^2.26.0",
-        "aws-cdk-lib": "2.26.0",
+        "aws-cdk-lib": "^2.26.0",
         "aws-cdk-local": "^2.15.0",
         "constructs": "^10.0.0",
         "esno": "^0.16.3",
@@ -18333,15 +18353,15 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.26.0.tgz",
-      "integrity": "sha512-FkTD79U7WRroI3J0fOuIv5DE2uhgIw2F1Z4Fz5XgrMDYB+F4F02/ud6YT+E4vIkUJkb+Jwlh814dDhZ53uYgUw==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.31.0.tgz",
+      "integrity": "sha512-6GvBmHtUx74uffl6kzvTL1bWN2/qPj4oHQj12gtqPifFBbNNrYGjLEeBY6DuidLhg96OoRoFc3lyJoiB/p7BEw==",
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
         "semver": "^7.3.7",
@@ -18403,7 +18423,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.0",
+          "version": "1.4.1",
           "bundled": true
         },
         "lru-cache": {


### PR DESCRIPTION
Adds the starter S3 and Glue resources for #37. The Glue table schemas are still specific to IoTeX from our prior work on stake ranking, but they'll serve as a meaningful starting point for our standardized cross-chain (and off-chain) event and aggregate tables.

I will follow up with minor cleanup work over the next few days.