### PR TITLE
Add reachable cosmos testnet url

### DIFF
--- a/apps/website/src/components/KeplrFaucetSender.vue
+++ b/apps/website/src/components/KeplrFaucetSender.vue
@@ -13,10 +13,18 @@
     <fieldset>
       <legend>Send</legend>
       <p>To faucet:</p>
-      <input value="{{toSend}}" type="number" @model="onToSendChanged" />
+      <input
+        value="{{toSend}}"
+        type="number"
+        @model="onToSendChanged"
+      >
       {{ denom }}
-      <button @click="onSendClicked">Send to faucet</button>
-      <button @click="updateFaucetBalance">Update faucet balance</button>
+      <button @click="onSendClicked">
+        Send to faucet
+      </button>
+      <button @click="updateFaucetBalance">
+        Update faucet balance
+      </button>
     </fieldset>
   </div>
 </template>
@@ -44,7 +52,7 @@ const myAddress = ref('Click first')
 const myBalance = ref('Click first')
 const toSend = ref('0')
 const faucetAddress = 'cosmos15aptdqmm7ddgtcrjvc5hs988rlrkze40l4q0he'
-const url = 'https://rpc-cosmoshub.keplr.app'
+const rpcUrl = 'https://rpc.testnet.cosmos.network:443'
 
 // TODO: Potentially add an onMounted hook to update the faucet balance per section above this: https://tutorials.cosmos.network/academy/xl-cosmjs/with-keplr.html#getting-testnet-tokens
 
@@ -60,12 +68,7 @@ async function onSendClicked(e) {
 
 // Get the faucet's balance
 async function updateFaucetBalance() {
-  const client = await StargateClient.connect({
-    url,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-    },
-  })
+  const client = await StargateClient.connect(rpcUrl)
   console.log('client :>> ', client)
   // const balances: readonly Coin[] = await client.getAllBalances(faucetAddress)
   // const first: Coin = balances[0]


### PR DESCRIPTION
Only adding a hardcoded Testnet URL, but here are some findings that will either be immediately useful or will be something we come back to:
- [Cosmos nodes have CORS disabled by default](https://docs.cosmos.network/main/run-node/interact-node.html#cross-origin-resource-sharing-cors)
- The Testnet node we're using here has CORS fully enabled for development purposes
- We'll set our production node's CORS policy for Casimir
- Using a reverse proxy for the public Testnets helped overcome restricted CORS, but led to, or revealed, authorization errors (which [we could speculate about](https://github.com/cosmos/cosmjs/issues/1007) but instead we'll configure our production node as needed when we get there)
- Regardless, for now, you'll probably want to go back to [creating a testnet account](https://tutorials.cosmos.network/academy/5-cosmjs/first-steps.html#testnet-preparation) and [adding the testnet to Keplr](https://tutorials.cosmos.network/academy/5-cosmjs/with-keplr.html#prepare-keplr), but swap in the reachable RPC URL