### PR TITLE
Complete retrieve last Block

### DIFF
--- a/common/data/src/index.ts
+++ b/common/data/src/index.ts
@@ -20,7 +20,12 @@ export function schemaToGlueColumns(jsonSchema: JsonSchema): glue.Column[] {
     let type: glue.Type = glue.Schema[typeKey]
 
     if (name.endsWith('_at')) type = glue.Schema.DATE
+
     if (name === 'candidate_list') type = glue.Schema.array(glue.Schema.STRING)
+
+    if (name === 'amount') type = glue.Schema.BIG_INT
+
+    if (name === 'total_staked_amount') type = glue.Schema.BIG_INT
 
     const comment = property.description
     return { name, type, comment }

--- a/common/data/src/schemas/event.schema.json
+++ b/common/data/src/schemas/event.schema.json
@@ -45,7 +45,7 @@
             "description": "The list of candidates in a stake action"
         },
         "amount": {
-            "type": "integer",
+            "type": "string",
             "description": "The amount of the currency in the event"
         },
         "duration":{

--- a/services/crawler/test/crawler.test.ts
+++ b/services/crawler/test/crawler.test.ts
@@ -2,24 +2,26 @@ import { crawler, Chain } from '../src/index'
 
 jest.setTimeout(20000)
 
-test('init crawler', async () => {
+test('get last block', async () => {
   const supercrawler = await crawler({
     chain: Chain.Iotex,
     verbose: true
   })
-  await supercrawler.retrieveLastBlock()
+
   expect(supercrawler.service).not.toBe(null)
+  const lastBlock = await supercrawler.retrieveLastBlock()
+  expect(typeof lastBlock).toBe('number')
 })
 
-test('stream', async () => {
-  const supercrawler = await crawler({
-    chain: Chain.Iotex,
-    verbose: true
-  })
-
-  expect(supercrawler).not.toBe(null)
-  // supercrawler.on('block', (block) => {
-  //   console.log(block)
-  // })
-})
-
+// test('stream', async () => {
+//   const supercrawler = await crawler({
+//     chain: Chain.Iotex,
+//     verbose: true
+//   })
+//
+//   expect(supercrawler).not.toBe(null)
+//   // supercrawler.on('block', (block) => {
+//   //   console.log(block)
+//   // })
+// })
+//


### PR DESCRIPTION
The branch name is a bit misleading, to summarize:
- Completed `retrieveLastBlock`. If the manual backoff gives us an issue switching to athena-express is easy (for now one less dep to deal with)
- Changed type of **amount** from int to string. To test the new schema check out `temp_event_v3` in the athena console to confirm this PR's change.
- Some more cleaning