### PR TITLE
Change -e (expose) flag to -x (external) for local/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,14 @@ You can get up and running without configuration. You can also mock local backen
     ```zsh
     npm run dev --trezor
     ```
+
+5. Expose any servers running on local ports using local tunnel.
+
+    ```zsh
+    npm run dev --external
+    ```
     
-5. The commands and flags above apply to any package in the [apps](apps/) directory. While the default app is [@casimir/web](apps/web/), you can specify others by passing a subcommand to `npm run dev`.
+6. The commands and flags above apply to any package in the [apps](apps/) directory. While the default app is [@casimir/web](apps/web/), you can specify others by passing a subcommand to `npm run dev`.
 
     ```zsh
     # @casimir/web
@@ -148,13 +154,13 @@ Run local cryptonodes for fast and flexible development.
 2. Run a local Ethereum node with archived data from mainnet.
 
     ```zsh
-    npm run dev:ethereum --fork mainnet
+    npm run dev:ethereum --fork=mainnet
     ```
 
 3. Run a local Ethereum node with archived data from Goerli testnet.
 
     ```zsh
-    npm run dev:ethereum --fork testnet
+    npm run dev:ethereum --fork=testnet
     ```
 
 > 🚩 Note, while the fork starts with the same state as the specified network, it lives as a local development network.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "npm exec --workspaces -- npx rimraf node_modules && npx rimraf node_modules && npm i",
     "deploy": "scripts/cdk/deploy -d infrastructure/cdk",
-    "dev": "scripts/local/dev -e \"$npm_config_expose\" -f \"$npm_config_fork\" -l \"$npm_config_ledger\" -m \"$npm_config_mock\" -n \"$npm_config_network\" -t \"$npm_config_trezor\"",
+    "dev": "scripts/local/dev -f \"$npm_config_fork\" -l \"$npm_config_ledger\" -m \"$npm_config_mock\" -n \"$npm_config_network\" -t \"$npm_config_trezor\" -x \"$npm_config_external\"",
     "dev:crawler": "scripts/crawler/dev -c \"$npm_config_chains\" -f \"$npm_config_fork\" -n \"$npm_config_network\" -u \"$npm_config_upload\"",
     "dev:ethereum": "scripts/ethereum/dev -f \"$npm_config_fork\"",
     "dev:landing": "npm run dev --workspace @casimir/landing",

--- a/scripts/local/dev
+++ b/scripts/local/dev
@@ -9,7 +9,7 @@
 # See https://docs.aws.amazon.com/cdk/api/v2/
 #
 
-# Configure and expose variables
+# Configure and external variables
 source scripts/aws/configure
 
 # Set RPC URL bases
@@ -37,14 +37,22 @@ while getopts :a:f:l:m:n:t: flag
 do
     case "${flag}" in
         a) app=${OPTARG};;
-        e) expose=${OPTARG};;
         f) fork=${OPTARG};;
         l) ledger=${OPTARG};;
         m) mock=${OPTARG};;
         n) network=${OPTARG};;
         t) trezor=${OPTARG};;
+        x) external=${OPTARG};;
     esac
 done
+
+echo "APP set to $app"
+echo "EXPOSE set to $external"
+echo "FORK set to $fork"
+echo "LEDGER set to $ledger"
+echo "MOCK set to $mock"
+echo "NETWORK set to $network"
+echo "TREZOR set to $trezor"
 
 # Default to mainnet if fork is set vaguely
 if [ "$fork" = true ]; then
@@ -97,8 +105,8 @@ else
         export PUBLIC_SSV_ADDRESS="0x967ada0ed736fc6916dabe7f0193bab811c74f50"
         
         # Tunnel local (default) chain networks if specified
-        if [ -n "$expose" ]; then
-            export LOCAL_TUNNEL="$expose"
+        if [ -n "$external" ]; then
+            export LOCAL_TUNNEL="$external"
         fi
     fi
 fi


### PR DESCRIPTION
Quick review and merge here. I introduced a faulty flag in your previous PR. `npm run dev --ledger` and `npm run dev --trezor` should work as expected now (so you can reduce down to one terminal if you'd like). 