### PR TITLE
Dynamically calculate fees from SSV smart contract and show on front-end

### DIFF
--- a/apps/web/src/composables/ethers.ts
+++ b/apps/web/src/composables/ethers.ts
@@ -80,8 +80,7 @@ export default function useEthers() {
 
   async function loginWithEthers ( providerString: ProviderString, selectedAccount: string) {
     const browserProvider = availableProviders.value[providerString as keyof BrowserProviders]
-    const web3Provider: ethers.providers.Web3Provider =
-      new ethers.providers.Web3Provider(browserProvider as EthersProvider)
+    const web3Provider: ethers.providers.Web3Provider = new ethers.providers.Web3Provider(browserProvider as EthersProvider)
     const messageJson = await getMessage(selectedAccount)
     const { message } = await messageJson.json()
     const signer = web3Provider.getSigner()

--- a/apps/web/src/composables/ssv.ts
+++ b/apps/web/src/composables/ssv.ts
@@ -1,6 +1,26 @@
 import { ethers } from 'ethers'
 import { SSVManager } from '@casimir/ethereum/build/artifacts/types'
 import { abi } from '@casimir/ethereum/build/artifacts/src/SSVManager.sol/SSVManager.json'
+import { ProviderString } from '@/types/ProviderString'
+
+// TODO: This is now duplicated in wallet.ts and ssv.ts
+import useEthers from '@/composables/ethers'
+import useLedger from '@/composables/ledger'
+import useTrezor from '@/composables/trezor'
+import useWalletConnect from '@/composables/walletConnect'
+
+const { getEthersBrowserSigner } = useEthers()
+const { getEthersLedgerSigner } = useLedger()
+const { getEthersTrezorSigner } = useTrezor()
+const { isWalletConnectSigner, getEthersWalletConnectSigner } = useWalletConnect()
+
+const ethersSignerCreator = {
+    'MetaMask': getEthersBrowserSigner,
+    'CoinbaseWallet': getEthersBrowserSigner,
+    'Ledger': getEthersLedgerSigner,
+    'Trezor': getEthersTrezorSigner,
+    'WalletConnect': getEthersWalletConnectSigner
+}
 
 export default function useSSV() {
     /** Instance of the SSV Manager contract */
@@ -16,5 +36,17 @@ export default function useSSV() {
         return new ethers.Contract(address, abi) as SSVManager
     })()
 
-    return { ssv }
+    async function getSSVFeePercent(selectedProvider: ProviderString) {
+        const signerKey = selectedProvider as keyof typeof ethersSignerCreator
+        let signer = ethersSignerCreator[signerKey](selectedProvider)
+        if (isWalletConnectSigner(signer)) signer = await signer
+        const ssvProvider = ssv.connect(signer as ethers.Signer)
+        const fees = await ssvProvider.getFees()
+        const { LINK, SSV } = fees
+        const feesTotalPercent = LINK + SSV
+        const feesRounded = Math.round(feesTotalPercent * 100) / 100
+        return feesRounded
+    }
+
+    return { ssv, getSSVFeePercent }
 }

--- a/apps/web/src/composables/wallet.ts
+++ b/apps/web/src/composables/wallet.ts
@@ -25,7 +25,7 @@ const selectedAccount = ref<string>('0xd557a5745d4560B24D36A68b52351ffF9c86A212'
 
 export default function useWallet() {
   const { ethereumURL } = useEnvironment()
-  const { ssv } = useSSV()
+  const { ssv, getSSVFeePercent } = useSSV()
   const { ethersProviderList, getEthersBrowserSigner, getEthersAddress, sendEthersTransaction, signEthersMessage, loginWithEthers } = useEthers()
   const { solanaProviderList, getSolanaAddress, sendSolanaTransaction, signSolanaMessage } = useSolana()
   const { getIoPayAddress, sendIoPayTransaction, signIoPayMessage } = useIoPay()
@@ -199,9 +199,7 @@ export default function useWallet() {
     let signer = ethersSignerCreator[signerKey](selectedProvider.value)
     if (isWalletConnectSigner(signer)) signer = await signer
     const ssvProvider = ssv.connect(signer as ethers.Signer)
-    const fees = await ssvProvider.getFees()
-    const { LINK, SSV } = fees
-    const feesTotalPercent = LINK + SSV
+    const feesTotalPercent = await getSSVFeePercent(selectedProvider.value)
     const depositAmount = parseFloat(amountToStake.value) * ((100 + feesTotalPercent) / 100)
     const value = ethers.utils.parseEther(depositAmount.toString())
     const result = await ssvProvider.deposit({ value, type: 0 })

--- a/apps/web/src/pages/staking/components/ETHConfirmStake.vue
+++ b/apps/web/src/pages/staking/components/ETHConfirmStake.vue
@@ -4,16 +4,31 @@ import { ref } from 'vue'
 import useFormat from '@/composables/format'
 import useUsers from '@/composables/users'
 import useWallet from '@/composables/wallet'
+import useSSV from '@/composables/ssv'
 
 const { formatDecimalString } = useFormat()
 const { user } = useUsers()
-const { amountToStake, deposit } = useWallet()
+const { amountToStake, selectedProvider, deposit } = useWallet()
+const { getSSVFeePercent } = useSSV()
+
+async function getFee() {
+  try {
+    const fee = await getSSVFeePercent(selectedProvider.value)
+    if (fee % 1 === 0) {
+        return `${fee}.00%`
+    }
+    return `${fee}%`
+  } catch (err){
+    console.error(err)
+    return 'Error connecting to SSV network. Please try again momentarily.'
+  }
+}
 
 const stakingInfo = ref(
     {
         to: 'Distributed SSV Validator',
         amount: formatDecimalString(amountToStake.value),
-        fees: '2.00%',
+        fees: await getFee(),
         expectedRewards: '5.67%',
         from: {
             name: 'MetaMask',

--- a/contracts/ethereum/docs/index.md
+++ b/contracts/ethereum/docs/index.md
@@ -331,6 +331,20 @@ Receives the response in the form of uint32
 | _requestId | bytes32 | - id of the request |
 | _data | uint32 | - response |
 
+### stakePool
+
+```solidity
+function stakePool(uint32 _poolId) private view
+```
+
+Stakes a pool
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _poolId | uint32 | - the stake pool's ID |
+
 ### getOpenPoolIds
 
 ```solidity


### PR DESCRIPTION
@shanejearley - Submitting PR for #199. Fees are being calculated dynamically now using the SSV methods. One thing you mentioned verbally (not written in the issue itself), is that we may want to extract the staking code and place somewhere else since it is not universally applicable across wallets (ethers wallets only). I tried doing that, but moving the `ethersSignerCreator` object from `wallet.ts` composable to the `ethers.ts` composable is causing "wackamole"-type errors. Hitting a wall of productivity on that front; so will plan to revisit. Submitting this for now because it is working, but the code could be DRYer.

@DemogorGod - Note the changes to `ETHConfirmStake.vue`. Feel free to give me some feedback there.

Thanks!