### PR TITLE
Add try catch around cdk bootstrap to catch deletion rejections

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build || echo 'Warning: @casimir/web build failed because script + dependency issues are unresolved. Disregard this warning and any listed errors above if @casimir/web is not needed for the current project build.' && exit 0",
+    "build": "vue-tsc --noEmit && vite build || echo '@casimir/web build failed because script + dependency issues are unresolved. Disregard any errors listed above this line.' && exit 0",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/infrastructure/cdk/package.json
+++ b/infrastructure/cdk/package.json
@@ -8,6 +8,7 @@
         "pretest": "export PROJECT=casimir && export STAGE=test",
         "test": "jest",
         "cdk:bootstrap": "npx cdk bootstrap",
+        "cdk:metadata": "npx cdk metadata",
         "cdk:synth": "npx cdk synth --no-staging"
     },
     "devDependencies": {

--- a/scripts/ethereum/dev.ts
+++ b/scripts/ethereum/dev.ts
@@ -1,6 +1,5 @@
 import { $, argv, echo, chalk } from 'zx'
 import { getSecret } from '@casimir/aws-helpers'
-import { getWallet } from '@casimir/ethers-helpers'
 
 /**
  * Run local a local Ethereum node and deploy contracts
@@ -30,7 +29,7 @@ void async function () {
     }
 
     // Enable 12-second interval mining for dev networks
-    process.env.INTERVAL_MINING = 'false'
+    process.env.INTERVAL_MINING = 'true'
 
     // Using hardhat local or fork network
     process.env.MOCK_CHAINLINK = 'true'


### PR DESCRIPTION
I couldn't replicate the bug regardless of which profile I used or whether the current stage's (bootstrapped) CDK Toolkit stack already existed. But, if you run into it again the error is caught and ignored (and relies on the existing stack, which is fine, since this is just needed once per stage). Your current defaults (STAGE=dev in the scripts and PROFILE={your-consensus-dev-name} in the .env) should work. 