### PR TITLE
Add health check to users service

### DIFF
--- a/infrastructure/cdk/src/providers/network.ts
+++ b/infrastructure/cdk/src/providers/network.ts
@@ -23,8 +23,11 @@ export class NetworkStack extends cdk.Stack {
     const config = new Config()
 
     /** Create a stage-specific Ec2 VPC and ECS cluster */
-    this.vpc = new ec2.Vpc(this, config.getFullStackResourceName(this.name, 'vpc'))
-    this.cluster = new ecs.Cluster(this, config.getFullStackResourceName(this.name, 'cluster'), { vpc: this.vpc })
-
+    this.vpc = new ec2.Vpc(this, config.getFullStackResourceName(this.name, 'vpc'), {
+      natGateways: 0
+    })
+    this.cluster = new ecs.Cluster(this, config.getFullStackResourceName(this.name, 'cluster'), { 
+      vpc: this.vpc
+    })
   }
 }

--- a/infrastructure/cdk/src/providers/users.ts
+++ b/infrastructure/cdk/src/providers/users.ts
@@ -22,7 +22,8 @@ export class UsersStack extends cdk.Stack {
         const { certificate, cluster, hostedZone } = props
 
         /** Create a load-balanced service for the users express API */
-        new ecsPatterns.ApplicationLoadBalancedFargateService(this, config.getFullStackResourceName(this.name, 'fargate'), {
+        const usersService = new ecsPatterns.ApplicationLoadBalancedFargateService(this, config.getFullStackResourceName(this.name, 'fargate'), {
+            assignPublicIp: true,
             certificate,
             cluster,
             domainName: `${subdomains.users}.${rootDomain}`, // e.g. users.casimir.co or users.dev.casimir.co
@@ -35,6 +36,11 @@ export class UsersStack extends cdk.Stack {
                     STAGE: stage
                 }
             }
+        })
+        
+        /** Override the default health check path */
+        usersService.targetGroup.configureHealthCheck({
+            path: '/health'
         })
     }
 }

--- a/services/users/src/index.ts
+++ b/services/users/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors'
 import login from './routes/login'
 import auth from './routes/auth'
 import users from './routes/users'
+import health from './routes/health'
 
 const port = process.env.PUBLIC_AUTH_PORT || 4000
 
@@ -13,6 +14,7 @@ app.use(cors())
 app.use('/login', login)
 app.use('/auth', auth)
 app.use('/users', users)
+app.use('/health', health)
 
 app.listen(port)
 console.log(`Auth server listening on port ${port}`)

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -1,0 +1,9 @@
+import express from 'express'
+
+const router = express.Router()
+
+router.get('/', (_req, res) => {
+    res.status(200).send('OK')
+})
+
+export default router


### PR DESCRIPTION
Modifies the default health check path and adds it to the `users` service. Also assigned a public IP to the service which will result in the removal of an expensive NAT gateway and place the service in the VPC's public subnet. 

The first thing resolves a bug that will take down the service and the second saves costs.

See more from these [docs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedFargateService.html#tasksubnets) and this [tweet](https://twitter.com/quinnypig/status/1091042265995272192).