### PR TITLE
Update/calculate fees

### DIFF
--- a/apps/web/src/composables/ethers.ts
+++ b/apps/web/src/composables/ethers.ts
@@ -59,7 +59,7 @@ export default function useEthers() {
       // const gasEstimateInEth = ethers.utils.formatEther(gasEstimate)
       const fee = maxPriorityFeePerGasInWei?.mul(gasEstimate).add(maxFeePerGasInWei)
       const feeInWei = ethers.utils.formatEther(fee)
-      const feeInEth = ((parseInt(feeInWei) / 10**18).toFixed(8)).toString()
+      const feeInEth = (parseInt(feeInWei) / 10**18).toFixed(8).toString()
       return {
         gasEstimate,
         fee: feeInEth
@@ -78,7 +78,7 @@ export default function useEthers() {
    * @returns string in ETH
    * @deprecated
    * @see estimateEIP1559GasFee
-   */
+  */
   async function estimateLegacyGasFee(rpcUrl: string, unsignedTransaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>) {
     try {
       const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
@@ -247,6 +247,7 @@ export default function useEthers() {
   return { 
     addEthersNetwork,
     estimateEIP1559GasFee,
+    estimateLegacyGasFee,
     ethersProviderList,
     getMaxETHAfterFees,
     getEthersAddress,

--- a/apps/web/src/composables/ethers.ts
+++ b/apps/web/src/composables/ethers.ts
@@ -59,7 +59,7 @@ export default function useEthers() {
       // const gasEstimateInEth = ethers.utils.formatEther(gasEstimate)
       const fee = maxPriorityFeePerGasInWei?.mul(gasEstimate).add(maxFeePerGasInWei)
       const feeInWei = ethers.utils.formatEther(fee)
-      const feeInEth = (parseInt(feeInWei) / 10**18).toString()
+      const feeInEth = ((parseInt(feeInWei) / 10**18).toFixed(8)).toString()
       return {
         gasEstimate,
         fee: feeInEth
@@ -68,6 +68,33 @@ export default function useEthers() {
       console.error('There was an error in estimateGasFee :>> ', err)
       return {
         gasEstimate: '0',
+        fee: '0'
+      }
+    }
+  }
+
+  /**
+   * Estimate gas fee using legacy methodology
+   * @returns string in ETH
+   * @deprecated
+   * @see estimateEIP1559GasFee
+   */
+  async function estimateLegacyGasFee(rpcUrl: string, unsignedTransaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>) {
+    try {
+      const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+      const gasPrice = await provider.getGasPrice()
+      const gasLimit = await provider.estimateGas(unsignedTransaction as ethers.utils.Deferrable<ethers.providers.TransactionRequest>)
+      const fee = gasPrice.mul(gasLimit)
+      const feeInWei = ethers.utils.formatEther(fee)
+      const feeInEth = (parseInt(feeInWei) / 10**18).toFixed(8).toString()
+      return {
+        gasLimit,
+        fee: feeInEth
+      }
+    } catch (err) {
+      console.error('There was an error in estimateGasFee :>> ', err)
+      return {
+        gasLimit: '0',
         fee: '0'
       }
     }

--- a/apps/web/src/composables/wallet.ts
+++ b/apps/web/src/composables/wallet.ts
@@ -10,8 +10,8 @@ import { MessageInit, TransactionInit } from '@/interfaces/index'
 import * as Session from 'supertokens-web-js/recipe/session'
 import router from './router'
 
+// Test ethereum send from address : 0xd557a5745d4560B24D36A68b52351ffF9c86A212
 // Test ethereum send to address : 0xD4e5faa8aD7d499Aa03BDDE2a3116E66bc8F8203
-// Test ethereum send to address : 0xd557a5745d4560B24D36A68b52351ffF9c86A212
 // Test solana address: 7aVow9eVQjwn7Y4y7tAbPM1pfrE1TzjmJhxcRt8QwX5F
 // Test iotex send to address: acc://06da5e904240736b1e21ca6dbbd5f619860803af04ff3d54/acme
 // Test bitcoin send to address : 2N3Petr4LMH9tRneZCYME9mu33gR5hExvds
@@ -24,7 +24,7 @@ const activeWallets = ref([
   'Ledger',
   'IoPay',
 ] as ProviderString[])
-const amount = ref<string>('0.000001')
+const amount = ref<string>('1')
 const amountToStake = ref<string>('0.0')
 const userAddresses = ref<CryptoAddress[]>([])
 const loadingUserWallets = ref(false)
@@ -33,10 +33,10 @@ const selectedProvider = ref<ProviderString>('')
 const selectedAddress = ref<string>('')
 const selectedPathIndex = ref<string>('')
 const selectedCurrency = ref<Currency>('')
-const toAddress = ref<string>('2N3Petr4LMH9tRneZCYME9mu33gR5hExvds')
+const toAddress = ref<string>('0x728474D29c2F81eb17a669a7582A2C17f1042b57')
 
 export default function useWallet() {
-  const { ethersProviderList, getEthersAddress, getEthersAddressWithBalance, getEthersBalance, sendEthersTransaction, signEthersMessage, loginWithEthers, getEthersBrowserProviderSelectedCurrency, switchEthersNetwork } = useEthers()
+  const { estimateEIP1559GasFee, ethersProviderList, getEthersAddress, getEthersAddressWithBalance, getEthersBalance, sendEthersTransaction, signEthersMessage, loginWithEthers, getEthersBrowserProviderSelectedCurrency, switchEthersNetwork } = useEthers()
   const { solanaProviderList, getSolanaAddress, sendSolanaTransaction, signSolanaMessage } = useSolana()
   const { getLedgerAddress, loginWithLedger, sendLedgerTransaction, signLedgerMessage } = useLedger()
   const { getTrezorAddress, loginWithTrezor, sendTrezorTransaction, signTrezorMessage } = useTrezor()


### PR DESCRIPTION
@shanejearley - Opening this PR to close #322. I've exposed two methods in the `useEthers` composable that estimate fees in the EIP1559 way and also the pre-EIP 1559 / legacy way (for any wallets that aren't yet upgraded to EIP 1559 standard). I've also exposed a method that returns to front-end the max amount of ETH available at an address to perform an action based on the EIP 1559 fee estimate.